### PR TITLE
Fix the documentation redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<meta http-equiv="refresh" content="0; url=../../doc/html/stacktrace.html">
+<meta http-equiv="refresh" content="0; url=../../doc/html/boost_stacktrace.html">
 <title>Boost.Stacktrace</title>
 <style>
   body {
@@ -26,7 +26,7 @@
 <body>
   <p>
     Automatic redirection failed, please go to
-    <a href="../../doc/html/stacktrace.html">../../doc/html/stacktrace.html</a>
+    <a href="../../doc/html/boost_stacktrace.html">../../doc/html/boost_stacktrace.html</a>
   </p>
   <p>
     &copy; 2014-2017 Antony Polukhin


### PR DESCRIPTION
Currently the documentation is at:

http://www.boost.org/doc/libs/develop/doc/html/boost_stacktrace.html

The filename is generated from the document's id in quickbook. Since you don't have one, it generates an id from the title "Boost.Stacktrace", while is why the file is called `boost_stacktrace.html`. So either need to change the redirect file to go there, or add '[id stacktrace]' to the library details in your quickbook documentation.