### PR TITLE
Libbacktrace fallback to sym info when debug info is missing or incomplete

### DIFF
--- a/include/boost/stacktrace/detail/libbacktrace_impls.hpp
+++ b/include/boost/stacktrace/detail/libbacktrace_impls.hpp
@@ -105,8 +105,7 @@ struct to_string_using_backtrace {
                 boost::stacktrace::detail::libbacktrace_syminfo_callback,
                 boost::stacktrace::detail::libbacktrace_error_callback,
                 &data
-            )
-            ;
+            );
         }
         line = data.line;
     }

--- a/include/boost/stacktrace/detail/libbacktrace_impls.hpp
+++ b/include/boost/stacktrace/detail/libbacktrace_impls.hpp
@@ -145,6 +145,14 @@ inline std::string name_impl(const void* addr) {
             boost::stacktrace::detail::libbacktrace_full_callback,
             boost::stacktrace::detail::libbacktrace_error_callback,
             &data
+        )
+        ||
+        ::backtrace_syminfo(
+            state,
+            reinterpret_cast<uintptr_t>(addr),
+            boost::stacktrace::detail::libbacktrace_syminfo_callback,
+            boost::stacktrace::detail::libbacktrace_error_callback,
+            &data
         );
     }
     if (!res.empty()) {

--- a/include/boost/stacktrace/detail/libbacktrace_impls.hpp
+++ b/include/boost/stacktrace/detail/libbacktrace_impls.hpp
@@ -32,6 +32,13 @@ struct pc_data {
     std::size_t line;
 };
 
+inline void libbacktrace_syminfo_callback(void *data, uintptr_t /*pc*/, const char *symname, uintptr_t /*symval*/, uintptr_t /*symsize*/) {
+    pc_data& d = *static_cast<pc_data*>(data);
+    if (d.function && symname) {
+        *d.function = symname;
+    }
+}
+
 inline int libbacktrace_full_callback(void *data, uintptr_t /*pc*/, const char *filename, int lineno, const char *function) {
     pc_data& d = *static_cast<pc_data*>(data);
     if (d.filename && filename) {
@@ -90,7 +97,16 @@ struct to_string_using_backtrace {
                 boost::stacktrace::detail::libbacktrace_full_callback,
                 boost::stacktrace::detail::libbacktrace_error_callback,
                 &data
-            );
+            ) 
+            ||
+            ::backtrace_syminfo(
+                state,
+                reinterpret_cast<uintptr_t>(addr),
+                boost::stacktrace::detail::libbacktrace_syminfo_callback,
+                boost::stacktrace::detail::libbacktrace_error_callback,
+                &data
+            )
+            ;
         }
         line = data.line;
     }


### PR DESCRIPTION
This adds lookup in symbol table in case libbacktrace is fails to lookup in debug info e.g. in case it is incomplete or stripped away.