### PR TITLE
WIP: Collect at most as many frames as requested.

### DIFF
--- a/include/boost/stacktrace/stacktrace.hpp
+++ b/include/boost/stacktrace/stacktrace.hpp
@@ -15,7 +15,6 @@
 #include <boost/core/explicit_operator_bool.hpp>
 #include <boost/container_hash/hash_fwd.hpp>
 
-#include <algorithm>
 #include <iosfwd>
 #include <string>
 #include <vector>
@@ -73,7 +72,7 @@ class basic_stacktrace {
         try {
             {   // Fast path without additional allocations
                 native_frame_ptr_t buffer[buffer_size];
-                const std::size_t frames_count = boost::stacktrace::detail::this_thread_frames::collect(buffer, std::min(buffer_size, max_depth), frames_to_skip + 1);
+                const std::size_t frames_count = boost::stacktrace::detail::this_thread_frames::collect(buffer, buffer_size < max_depth ? buffer_size : max_depth, frames_to_skip + 1);
                 if (buffer_size > frames_count || frames_count >= max_depth) {
                     const std::size_t size = (max_depth < frames_count ? max_depth : frames_count);
                     fill(buffer, size);

--- a/include/boost/stacktrace/stacktrace.hpp
+++ b/include/boost/stacktrace/stacktrace.hpp
@@ -88,7 +88,7 @@ class basic_stacktrace {
 #endif
             std::vector<native_frame_ptr_t, allocator_void_t> buf(buffer_size * 2, 0, impl_.get_allocator());
             do {
-                const std::size_t frames_count = boost::stacktrace::detail::this_thread_frames::collect(&buf[0], buf.size(), frames_to_skip + 1);
+                const std::size_t frames_count = boost::stacktrace::detail::this_thread_frames::collect(&buf[0], buf.size() < max_depth ? buf.size() : max_depth, frames_to_skip + 1);
                 if (buf.size() > frames_count || frames_count >= max_depth) {
                     const std::size_t size = (max_depth < frames_count ? max_depth : frames_count);
                     fill(&buf[0], size);

--- a/include/boost/stacktrace/stacktrace.hpp
+++ b/include/boost/stacktrace/stacktrace.hpp
@@ -73,7 +73,6 @@ class basic_stacktrace {
             {   // Fast path without additional allocations
                 native_frame_ptr_t buffer[buffer_size];
                 const std::size_t frames_count = boost::stacktrace::detail::this_thread_frames::collect(buffer, buffer_size < max_depth ? buffer_size : max_depth, frames_to_skip + 1);
-                    fill(buffer, size);
                 if (buffer_size > frames_count || frames_count == max_depth) {
                     fill(buffer, frames_count);
                     return;

--- a/include/boost/stacktrace/stacktrace.hpp
+++ b/include/boost/stacktrace/stacktrace.hpp
@@ -15,6 +15,7 @@
 #include <boost/core/explicit_operator_bool.hpp>
 #include <boost/container_hash/hash_fwd.hpp>
 
+#include <algorithm>
 #include <iosfwd>
 #include <string>
 #include <vector>
@@ -72,7 +73,7 @@ class basic_stacktrace {
         try {
             {   // Fast path without additional allocations
                 native_frame_ptr_t buffer[buffer_size];
-                const std::size_t frames_count = boost::stacktrace::detail::this_thread_frames::collect(buffer, buffer_size, frames_to_skip + 1);
+                const std::size_t frames_count = boost::stacktrace::detail::this_thread_frames::collect(buffer, std::min(buffer_size, max_depth), frames_to_skip + 1);
                 if (buffer_size > frames_count || frames_count >= max_depth) {
                     const std::size_t size = (max_depth < frames_count ? max_depth : frames_count);
                     fill(buffer, size);

--- a/include/boost/stacktrace/stacktrace.hpp
+++ b/include/boost/stacktrace/stacktrace.hpp
@@ -73,9 +73,9 @@ class basic_stacktrace {
             {   // Fast path without additional allocations
                 native_frame_ptr_t buffer[buffer_size];
                 const std::size_t frames_count = boost::stacktrace::detail::this_thread_frames::collect(buffer, buffer_size < max_depth ? buffer_size : max_depth, frames_to_skip + 1);
-                if (buffer_size > frames_count || frames_count >= max_depth) {
-                    const std::size_t size = (max_depth < frames_count ? max_depth : frames_count);
                     fill(buffer, size);
+                if (buffer_size > frames_count || frames_count == max_depth) {
+                    fill(buffer, frames_count);
                     return;
                 }
             }
@@ -89,9 +89,8 @@ class basic_stacktrace {
             std::vector<native_frame_ptr_t, allocator_void_t> buf(buffer_size * 2, 0, impl_.get_allocator());
             do {
                 const std::size_t frames_count = boost::stacktrace::detail::this_thread_frames::collect(&buf[0], buf.size() < max_depth ? buf.size() : max_depth, frames_to_skip + 1);
-                if (buf.size() > frames_count || frames_count >= max_depth) {
-                    const std::size_t size = (max_depth < frames_count ? max_depth : frames_count);
-                    fill(&buf[0], size);
+                if (buf.size() > frames_count || frames_count == max_depth) {
+                    fill(&buf[0], frames_count);
                     return;
                 }
 


### PR DESCRIPTION
Regardless of any user provided maximum stack depth `boost::stacktrace::basic_stacktrace<>::init` will try to obtain 128 stack frames.

For older Microsoft platforms like Windows Server 2003 and Windows XP this is problematic as `RtlCaptureStackBacktrace` has a stricter [limit](https://msdn.microsoft.com/de-de/library/windows/desktop/bb204633(v=vs.85).aspx) on the stack depth.
