### PR TITLE
Added an option to use libc backtrace function from execinfo.h

### DIFF
--- a/include/boost/stacktrace/detail/collect_unwind.ipp
+++ b/include/boost/stacktrace/detail/collect_unwind.ipp
@@ -14,6 +14,13 @@
 
 #include <boost/stacktrace/safe_dump_to.hpp>
 
+// On iOS 32-bit ARM architecture _Unwind_Backtrace function doesn't exist, symbol is undefined.
+// Forcing libc backtrace() function usage.
+#include <boost/predef.h>
+#if defined(BOOST_OS_IOS_AVAILABLE) && defined(BOOST_ARCH_ARM_AVAILABLE) && BOOST_VERSION_NUMBER_MAJOR(BOOST_ARCH_ARM) < 8
+#define BOOST_STACKTRACE_USE_LIBC_BACKTRACE_FUNCTION
+#endif
+
 #if defined(BOOST_STACKTRACE_USE_LIBC_BACKTRACE_FUNCTION)
 #include <execinfo.h>
 #include <algorithm>

--- a/include/boost/stacktrace/detail/collect_unwind.ipp
+++ b/include/boost/stacktrace/detail/collect_unwind.ipp
@@ -98,4 +98,6 @@ std::size_t this_thread_frames::collect(native_frame_ptr_t* out_frames, std::siz
 
 }}} // namespace boost::stacktrace::detail
 
+#undef BOOST_STACKTRACE_USE_LIBC_BACKTRACE_FUNCTION
+
 #endif // BOOST_STACKTRACE_DETAIL_COLLECT_UNWIND_IPP


### PR DESCRIPTION
* Added new definition BOOST_STACKTRACE_USE_LIBC_BACKTRACE_FUNCTION
* Set on iOS 32-bit platforms. See https://github.com/boostorg/stacktrace/issues/46