### PR TITLE
Don't initialize COM

### DIFF
--- a/include/boost/stacktrace/detail/frame_msvc.ipp
+++ b/include/boost/stacktrace/detail/frame_msvc.ipp
@@ -151,11 +151,10 @@ public:
     static com_holder< ::IDebugSymbols>& get_thread_local_debug_inst() BOOST_NOEXCEPT {
         // [class.mfct]: A static local variable or local type in a member function always refers to the same entity, whether
         // or not the member function is inline.
-        static thread_local boost::stacktrace::detail::com_global_initer com;
-        static thread_local com_holder< ::IDebugSymbols> idebug(com);
+        static thread_local com_holder< ::IDebugSymbols> idebug;
 
         if (!idebug.is_inited()) {
-            try_init_com(idebug, com);
+            try_init_com(idebug);
         }
 
         return idebug;


### PR DESCRIPTION
Resolve #121

See the [documentation](https://docs.microsoft.com/windows-hardware/drivers/ddi/dbgeng/nf-dbgeng-debugcreate#remarks): 

> You don't need to call **CoInitialize**, **CoInitializeEx**, or **OleInitialize** to use this function and interfaces obtained by it.

Even if DIA support is implemented, there's a way to avoid `CoInitializeEx` for DIA too.