### PR TITLE
End WinDbg session to prevent memory from leaking

### DIFF
--- a/include/boost/stacktrace/detail/frame_msvc.ipp
+++ b/include/boost/stacktrace/detail/frame_msvc.ipp
@@ -174,7 +174,9 @@ public:
 
     ~debugging_symbols() BOOST_NOEXCEPT
     {
-        iclient_->EndSession(DEBUG_END_PASSIVE);
+        if (iclient_.is_inited()) {
+            iclient_->EndSession(DEBUG_END_PASSIVE);
+        }
     }
 
 #else


### PR DESCRIPTION
If **BOOST_STACKTRACE_USE_WINDBG** is defined, the implementation of `stacktrace::to_string` opens a new WinDbg session each time without ending the previous one which results in leaking memory (see #111).

This PR adds the missing [EndSession](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/dbgeng/nf-dbgeng-idebugclient-endsession) call in the `debugging_symbols` destructor.