### PR TITLE
fix addr2line for pie binaries

### DIFF
--- a/include/boost/stacktrace/detail/addr2line_impls.hpp
+++ b/include/boost/stacktrace/detail/addr2line_impls.hpp
@@ -156,7 +156,7 @@ inline std::string addr2line(const char* flag, const void* addr) {
     return res;
 }
 
-std::string source_location(const void* addr, bool position_independent) {
+inline std::string source_location(const void* addr, bool position_independent) {
     uintptr_t addr_base = 0;
     if (position_independent) {
         addr_base = boost::stacktrace::detail::get_own_proc_addr_base(addr);

--- a/include/boost/stacktrace/detail/addr_base.hpp
+++ b/include/boost/stacktrace/detail/addr_base.hpp
@@ -67,7 +67,7 @@ inline mapping_entry_t parse_proc_maps_line(const std::string& line) {
         mapping.offset_from_base = hex_str_to_int(offset_from_base_str);
         return mapping;
     } catch(std::invalid_argument& e) {
-        return boost::optional<mapping_entry_t>();
+        return mapping_entry_t{};
     }
 }
 

--- a/include/boost/stacktrace/detail/addr_base.hpp
+++ b/include/boost/stacktrace/detail/addr_base.hpp
@@ -22,7 +22,8 @@ struct mapping_entry_t {
     uintptr_t start = 0;
     uintptr_t end = 0;
     uintptr_t offset_from_base = 0;
-    inline bool contains_addr(const void* addr) {
+
+    inline bool contains_addr(const void* addr) const {
         uintptr_t addr_uint = reinterpret_cast<uintptr_t>(addr);
         return addr_uint >= start && addr_uint < end;
     }
@@ -74,9 +75,9 @@ inline mapping_entry_t parse_proc_maps_line(const std::string& line) {
 inline uintptr_t get_own_proc_addr_base(const void* addr) {
     std::ifstream maps_file("/proc/self/maps");
     for (std::string line; std::getline(maps_file, line); ) {
-        mapping_entry_t mapping = parse_proc_maps_line(line);
-        if (mapping->contains_addr(addr)) {
-            return mapping->start - mapping->offset_from_base;
+        const mapping_entry_t mapping = parse_proc_maps_line(line);
+        if (mapping.contains_addr(addr)) {
+            return mapping.start - mapping.offset_from_base;
         }
     }
     return 0;

--- a/include/boost/stacktrace/detail/addr_base.hpp
+++ b/include/boost/stacktrace/detail/addr_base.hpp
@@ -21,7 +21,6 @@
 namespace boost { namespace stacktrace { namespace detail {
 
 struct mapping_entry_t {
-    // TODO uintptr_t are not in C++03?
     uintptr_t start;
     uintptr_t end;
     uintptr_t offset_from_base;
@@ -55,13 +54,13 @@ inline boost::optional<mapping_entry_t> parse_proc_maps_line(const std::string& 
     if(!std::getline(line_stream, mapping_range_str, ' ') ||
         !std::getline(line_stream, permissions_str, ' ') ||
         !std::getline(line_stream, offset_from_base_str, ' ')) {
-        return {};
+        return boost::optional<mapping_entry_t>();
     }
     std::string mapping_start_str, mapping_end_str;
     std::istringstream mapping_range_stream(mapping_range_str);
     if(!std::getline(mapping_range_stream, mapping_start_str, '-') ||
         !std::getline(mapping_range_stream, mapping_end_str)) {
-        return {};
+        return boost::optional<mapping_entry_t>();
     }
     mapping_entry_t mapping;
     try {
@@ -70,7 +69,7 @@ inline boost::optional<mapping_entry_t> parse_proc_maps_line(const std::string& 
         mapping.offset_from_base = hex_str_to_int(offset_from_base_str);
         return mapping;
     } catch(std::invalid_argument& e) {
-        return {};
+        return boost::optional<mapping_entry_t>();
     }
 }
 

--- a/include/boost/stacktrace/detail/addr_base.hpp
+++ b/include/boost/stacktrace/detail/addr_base.hpp
@@ -1,0 +1,90 @@
+// Copyright Antony Polukhin, 2016-2023.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_STACKTRACE_DETAIL_ADDR_BASE_HPP
+#define BOOST_STACKTRACE_DETAIL_ADDR_BASE_HPP
+
+#include <boost/config.hpp>
+#ifdef BOOST_HAS_PRAGMA_ONCE
+#   pragma once
+#endif
+
+#include <fstream>
+#include <sstream>
+#include <cstdlib>
+
+#include <boost/optional.hpp>
+
+namespace boost { namespace stacktrace { namespace detail {
+
+struct mapping_entry_t {
+    // TODO uintptr_t are not in C++03?
+    uintptr_t start;
+    uintptr_t end;
+    uintptr_t offset_from_base;
+    inline bool contains_addr(const void* addr) {
+        uintptr_t addr_uint = reinterpret_cast<uintptr_t>(addr);
+        return addr_uint >= start && addr_uint < end;
+    }
+};
+
+inline uintptr_t hex_str_to_int(const std::string& str) {
+    uintptr_t out;
+    std::stringstream ss;
+    ss << std::hex << str;
+    ss >> out;
+    if(ss.eof() && !ss.fail()) { // whole stream read, with no errors
+        return out;
+    } else {
+        throw std::invalid_argument(std::string("can't convert '") + str + "' to hex");
+    }
+}
+
+// parse line from /proc/<id>/maps
+// format:
+// 7fb60d1ea000-7fb60d20c000 r--p 00000000 103:02 120327460                 /usr/lib/libc.so.6
+// only parts 0 and 2 are interesting, these are:
+//  0. mapping address range
+//  2. mapping offset from base
+inline boost::optional<mapping_entry_t> parse_proc_maps_line(const std::string& line) {
+    std::string mapping_range_str, permissions_str, offset_from_base_str;
+    std::istringstream line_stream(line);
+    if(!std::getline(line_stream, mapping_range_str, ' ') ||
+        !std::getline(line_stream, permissions_str, ' ') ||
+        !std::getline(line_stream, offset_from_base_str, ' ')) {
+        return {};
+    }
+    std::string mapping_start_str, mapping_end_str;
+    std::istringstream mapping_range_stream(mapping_range_str);
+    if(!std::getline(mapping_range_stream, mapping_start_str, '-') ||
+        !std::getline(mapping_range_stream, mapping_end_str)) {
+        return {};
+    }
+    mapping_entry_t mapping;
+    try {
+        mapping.start = hex_str_to_int(mapping_start_str);
+        mapping.end = hex_str_to_int(mapping_end_str);
+        mapping.offset_from_base = hex_str_to_int(offset_from_base_str);
+        return mapping;
+    } catch(std::invalid_argument& e) {
+        return {};
+    }
+}
+
+inline uintptr_t get_own_proc_addr_base(const void* addr) {
+    std::ifstream maps_file("/proc/self/maps");
+    for (std::string line; std::getline(maps_file, line); ) {
+        boost::optional<mapping_entry_t> mapping = parse_proc_maps_line(line);
+        if (mapping && mapping->contains_addr(addr)) {
+            return mapping->start - mapping->offset_from_base;
+        }
+    }
+    return 0;
+}
+
+}}} // namespace boost::stacktrace::detail
+
+#endif // BOOST_STACKTRACE_DETAIL_ADDR_BASE_HPP


### PR DESCRIPTION
`addr2line` can't translate addresses from position independent binaries, it needs offsets from binary base. Here it's achieved by reading `/proc/self/maps` (to be honest, I don't know how portable exactly that is, but judging from the fact that `/proc/self/exe` is read, that is not a huge concern?).

Most likely doesn't work with C++03, I can try to fix it if needed.

I'm not sure, but it might fix #97 or #113.

---

There's a commented out line 
```
//return addr2line("-Cfipe", addr); // Does not seem to work in all cases
```
It's likely that it'd work in more cases with my fix, if offsets from binary image base were passed to `addr2line` - in that case, I think it might be wise to just use it as it was before, and get both function name and file info from `addr2line`, as it seems to be more robust than `dladdr` (`addr2line` should work for all binaries with debug info, while `dl` functions probably only work for exported symbols (and non-pie binaries, for some reason); maybe `dladdr` should still be left as a fallback).