### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,7 @@ jobs:
           - toolset: gcc-9
             cxxstd: "03,11,14,17,2a"
             os: ubuntu-22.04
-          - toolset: clang
-            compiler: clang++-15
+          - toolset: clang-15
             cxxstd: "03,11,14,17,2a"
             os: ubuntu-22.04
           # TODO: fix and uncomment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
             cxxstd: "03,11,14,17,2a"
             os: ubuntu-22.04
           - toolset: clang
-            compiler: clang++-14
+            compiler: clang++-15
             cxxstd: "03,11,14,17,2a"
             os: ubuntu-22.04
           # TODO: fix and uncomment

--- a/doc/stacktrace.qbk
+++ b/doc/stacktrace.qbk
@@ -295,43 +295,6 @@ Terminate called:
 
 [endsect]
 
-[/
-[section Store stacktraces into shared memory]
-
-There's a way to serialize stacktrace in async safe manner and share that serialized representation with another process. Here's another example with signal handlers.
-
-This example is very close to the [link stacktrace.getting_started.handle_terminates_aborts_and_seg "Handle terminates, aborts and Segmentation Faults"], but this time we are dumping stacktrace into shared memory:
-
-[getting_started_terminate_handlers_shmem]
-
-After registering signal handlers and catching a signal, we may print stacktrace dumps on program restart:
-
-[getting_started_on_program_restart_shmem]
-
-The program output will be the following:
-
-```
-Previous run crashed and left trace in shared memory:
- 0# 0x00007FD51C7218EF
- 1# my_signal_handler2(int) at ../example/terminate_handler.cpp:68
- 2# 0x00007FD51B833CB0
- 3# 0x00007FD51B833C37
- 4# 0x00007FD51B837028
- 5# 0x00007FD51BE44BBD
- 6# 0x00007FD51BE42B96
- 7# 0x00007FD51BE42BE1
- 8# bar(int) at ../example/terminate_handler.cpp:18
- 9# foo(int) at ../example/terminate_handler.cpp:22
-10# bar(int) at ../example/terminate_handler.cpp:14
-11# foo(int) at ../example/terminate_handler.cpp:22
-12# run_3(char const**) at ../example/terminate_handler.cpp:152
-13# main at ../example/terminate_handler.cpp:207
-14# 0x00007FD51B81EF45
-15# 0x0000000000402999
-```
-
-[endsect] 
-]
 
 [endsect]
 

--- a/example/terminate_handler.cpp
+++ b/example/terminate_handler.cpp
@@ -63,13 +63,12 @@ void my_terminate_handler() {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#ifndef BOOST_WINDOWS
 #include <iostream>     // std::cerr
 #include <fstream>     // std::ifstream
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
 
-
+#ifndef BOOST_WINDOWS
 inline void copy_and_run(const char* exec_name, char param, bool not_null) {
     std::cout << "Running with param " << param << std::endl;
     boost::filesystem::path command = exec_name;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -117,20 +117,20 @@ test-suite stacktrace_tests
 
     # Thread safety with debug symbols
     [ run thread_safety_checking.cpp
-        : : : <debug-symbols>on <library>/boost/thread//boost_thread <library>/boost/timer//boost_timer <library>.//test_impl_lib_backtrace       $(LINKSHARED_BT)
+        : : : <debug-symbols>on <library>.//test_impl_lib_backtrace       $(LINKSHARED_BT)
         : backtrace_lib_threaded ]
     [ run thread_safety_checking.cpp
-        : : : <debug-symbols>on <library>/boost/thread//boost_thread <library>/boost/timer//boost_timer <library>.//test_impl_lib_backtrace       $(LINKSHARED_BT)
+        : : : <debug-symbols>on <library>.//test_impl_lib_backtrace       $(LINKSHARED_BT)
               <define>BOOST_STACKTRACE_BACKTRACE_FORCE_STATIC
         : backtrace_lib_threaded_static ]
     [ run thread_safety_checking.cpp
-        : : : <debug-symbols>on <library>/boost/thread//boost_thread <library>/boost/timer//boost_timer <library>.//test_impl_lib_windbg          $(LINKSHARED_WIND)
+        : : : <debug-symbols>on <library>.//test_impl_lib_windbg          $(LINKSHARED_WIND)
         : windbg_lib_threaded ]
     [ run thread_safety_checking.cpp
-        : : : <debug-symbols>on <library>/boost/thread//boost_thread <library>/boost/timer//boost_timer <library>.//test_impl_lib_windbg_cached   $(LINKSHARED_WIND_CACHED)
+        : : : <debug-symbols>on <library>.//test_impl_lib_windbg_cached   $(LINKSHARED_WIND_CACHED)
         : windbg_cached_lib_threaded ]
     [ run thread_safety_checking.cpp
-        : : : <debug-symbols>on <library>/boost/thread//boost_thread <library>/boost/timer//boost_timer <library>.//test_impl_lib_basic           $(LINKSHARED_BASIC)
+        : : : <debug-symbols>on <library>.//test_impl_lib_basic           $(LINKSHARED_BASIC)
         : basic_lib_threaded ]
 
     ##### Tests with disabled debug symbols #####
@@ -157,29 +157,21 @@ test-suite stacktrace_tests
     # Thread safety without debug symbols
     [ run thread_safety_checking.cpp
         : : : <debug-symbols>off
-            <library>/boost/thread//boost_thread
-            <library>/boost/timer//boost_timer
             <library>.//test_impl_lib_backtrace_no_dbg
             $(LINKSHARED_BT)
         : backtrace_lib_no_dbg_threaded ]
     [ run thread_safety_checking.cpp
         : : : <debug-symbols>off
-            <library>/boost/thread//boost_thread
-            <library>/boost/timer//boost_timer
             <library>.//test_impl_lib_windbg_no_dbg
             $(LINKSHARED_WIND)
         : windbg_lib_no_dbg_threaded ]
     [ run thread_safety_checking.cpp
         : : : <debug-symbols>off
-            <library>/boost/thread//boost_thread
-            <library>/boost/timer//boost_timer
             <library>.//test_impl_lib_windbg_cached_no_dbg
             $(LINKSHARED_WIND_CACHED)
         : windbg_cached_lib_no_dbg_threaded ]
     [ run thread_safety_checking.cpp
         : : : <debug-symbols>off
-            <library>/boost/thread//boost_thread
-            <library>/boost/timer//boost_timer
             <library>.//test_impl_lib_basic_no_dbg
             $(LINKSHARED_BASIC)
         : basic_lib_no_dbg_threaded ]

--- a/test/appveyor.yml
+++ b/test/appveyor.yml
@@ -33,25 +33,26 @@ skip_tags: true
 environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      TOOLSET: msvc-14.1 # ,clang-win
+      TOOLSET: msvc-14.1,clang-win
       CXXSTD: 14,17
       ADDRMD: 64
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      ADDPATH: C:\cygwin\bin;
+      TOOLSET: gcc
+      CXXSTD: 03,11,14,1z
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      ADDPATH: C:\cygwin64\bin;
+      TOOLSET: gcc
+      CXXSTD: 03,11,14,1z
+    # Waiting for https://github.com/boostorg/system/issues/116
     #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-    #  ADDPATH: C:\cygwin\bin;
-    #  TOOLSET: gcc
-    #  CXXSTD: 03,11,14,1z
-    #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-    #  ADDPATH: C:\cygwin64\bin;
+    #  ADDPATH: C:\mingw\bin;
     #  TOOLSET: gcc
     #  CXXSTD: 03,11,14,1z
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      ADDPATH: C:\mingw\bin;
+      ADDPATH: C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;
       TOOLSET: gcc
       CXXSTD: 03,11,14,1z
-    #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-    #  ADDPATH: C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;
-    #  TOOLSET: gcc
-    #  CXXSTD: 03,11,14,1z
 
 before_build:
     - set BOOST_BRANCH=develop

--- a/test/appveyor.yml
+++ b/test/appveyor.yml
@@ -65,7 +65,7 @@ before_build:
     - git submodule update --init --depth 10 tools/build tools/boostdep
         libs/filesystem libs/atomic libs/system libs/interprocess libs/array
         libs/iterator libs/detail libs/exception libs/smart_ptr libs/mpl
-        libs/align libs/container libs/tuple libs/intrusive
+        libs/align libs/container libs/tuple libs/intrusive libs/scope
 
     - rm -rf %BOOST%/libs/%BOOST_LIBS_FOLDER%
     - mv -f %APPVEYOR_BUILD_FOLDER% %BOOST%/libs/%BOOST_LIBS_FOLDER%

--- a/test/appveyor.yml
+++ b/test/appveyor.yml
@@ -61,7 +61,7 @@ before_build:
     - set BOOST=C:/boost-local
     - git clone -b %BOOST_BRANCH% --depth 10 https://github.com/boostorg/boost.git %BOOST%
     - cd %BOOST%
-    - git submodule update --init --depth 10 tools/build tools/boostdep libs/filesystem libs/atomiclibs/system libs/interprocess
+    - git submodule update --init --depth 10 tools/build tools/boostdep libs/filesystem libs/atomic libs/system libs/interprocess
 
     - rm -rf %BOOST%/libs/%BOOST_LIBS_FOLDER%
     - mv -f %APPVEYOR_BUILD_FOLDER% %BOOST%/libs/%BOOST_LIBS_FOLDER%

--- a/test/appveyor.yml
+++ b/test/appveyor.yml
@@ -61,7 +61,10 @@ before_build:
     - set BOOST=C:/boost-local
     - git clone -b %BOOST_BRANCH% --depth 10 https://github.com/boostorg/boost.git %BOOST%
     - cd %BOOST%
-    - git submodule update --init --depth 10 tools/build tools/boostdep libs/filesystem libs/atomic libs/system libs/interprocess libs/array libs/iterator libs/detail libs/exception libs/smart_ptr libs/mpl
+    - git submodule update --init --depth 10 tools/build tools/boostdep
+        libs/filesystem libs/atomic libs/system libs/interprocess libs/array
+        libs/iterator libs/detail libs/exception libs/smart_ptr libs/mpl
+        libs/align libs/container libs/tuple
 
     - rm -rf %BOOST%/libs/%BOOST_LIBS_FOLDER%
     - mv -f %APPVEYOR_BUILD_FOLDER% %BOOST%/libs/%BOOST_LIBS_FOLDER%

--- a/test/appveyor.yml
+++ b/test/appveyor.yml
@@ -61,7 +61,7 @@ before_build:
     - set BOOST=C:/boost-local
     - git clone -b %BOOST_BRANCH% --depth 10 https://github.com/boostorg/boost.git %BOOST%
     - cd %BOOST%
-    - git submodule update --init --depth 10 tools/build tools/boostdep libs/filesystem libs/atomic libs/system libs/interprocess libs/array libs/iterator libs/detail libs/exception
+    - git submodule update --init --depth 10 tools/build tools/boostdep libs/filesystem libs/atomic libs/system libs/interprocess libs/array libs/iterator libs/detail libs/exception libs/smart_ptr libs/mpl
 
     - rm -rf %BOOST%/libs/%BOOST_LIBS_FOLDER%
     - mv -f %APPVEYOR_BUILD_FOLDER% %BOOST%/libs/%BOOST_LIBS_FOLDER%

--- a/test/appveyor.yml
+++ b/test/appveyor.yml
@@ -61,7 +61,7 @@ before_build:
     - set BOOST=C:/boost-local
     - git clone -b %BOOST_BRANCH% --depth 10 https://github.com/boostorg/boost.git %BOOST%
     - cd %BOOST%
-    - git submodule update --init --depth 10 tools/build tools/boostdep libs/filesystem libs/atomic libs/system libs/interprocess libs/array libs/iterator libs/detail
+    - git submodule update --init --depth 10 tools/build tools/boostdep libs/filesystem libs/atomic libs/system libs/interprocess libs/array libs/iterator libs/detail libs/exception
 
     - rm -rf %BOOST%/libs/%BOOST_LIBS_FOLDER%
     - mv -f %APPVEYOR_BUILD_FOLDER% %BOOST%/libs/%BOOST_LIBS_FOLDER%

--- a/test/appveyor.yml
+++ b/test/appveyor.yml
@@ -61,7 +61,7 @@ before_build:
     - set BOOST=C:/boost-local
     - git clone -b %BOOST_BRANCH% --depth 10 https://github.com/boostorg/boost.git %BOOST%
     - cd %BOOST%
-    - git submodule update --init --depth 10 tools/build tools/boostdep libs/filesystem libs/atomic libs/interprocess
+    - git submodule update --init --depth 10 tools/build tools/boostdep libs/filesystem libs/atomiclibs/system libs/interprocess
 
     - rm -rf %BOOST%/libs/%BOOST_LIBS_FOLDER%
     - mv -f %APPVEYOR_BUILD_FOLDER% %BOOST%/libs/%BOOST_LIBS_FOLDER%

--- a/test/appveyor.yml
+++ b/test/appveyor.yml
@@ -61,7 +61,7 @@ before_build:
     - set BOOST=C:/boost-local
     - git clone -b %BOOST_BRANCH% --depth 10 https://github.com/boostorg/boost.git %BOOST%
     - cd %BOOST%
-    - git submodule update --init --depth 10 tools/build tools/boostdep libs/filesystem libs/interprocess
+    - git submodule update --init --depth 10 tools/build tools/boostdep libs/filesystem libs/atomic libs/interprocess
 
     - rm -rf %BOOST%/libs/%BOOST_LIBS_FOLDER%
     - mv -f %APPVEYOR_BUILD_FOLDER% %BOOST%/libs/%BOOST_LIBS_FOLDER%

--- a/test/appveyor.yml
+++ b/test/appveyor.yml
@@ -61,7 +61,7 @@ before_build:
     - set BOOST=C:/boost-local
     - git clone -b %BOOST_BRANCH% --depth 10 https://github.com/boostorg/boost.git %BOOST%
     - cd %BOOST%
-    - git submodule update --init --depth 10 tools/build tools/boostdep libs/filesystem libs/atomic libs/system libs/interprocess libs/array
+    - git submodule update --init --depth 10 tools/build tools/boostdep libs/filesystem libs/atomic libs/system libs/interprocess libs/array libs/iterator libs/detail
 
     - rm -rf %BOOST%/libs/%BOOST_LIBS_FOLDER%
     - mv -f %APPVEYOR_BUILD_FOLDER% %BOOST%/libs/%BOOST_LIBS_FOLDER%

--- a/test/appveyor.yml
+++ b/test/appveyor.yml
@@ -33,26 +33,26 @@ skip_tags: true
 environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      TOOLSET: msvc-14.1,clang-win
+      TOOLSET: msvc-14.1 #,clang-win
       CXXSTD: 14,17
       ADDRMD: 64
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      ADDPATH: C:\cygwin\bin;
-      TOOLSET: gcc
-      CXXSTD: 03,11,14,1z
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      ADDPATH: C:\cygwin64\bin;
-      TOOLSET: gcc
-      CXXSTD: 03,11,14,1z
+    #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    #  ADDPATH: C:\cygwin\bin;
+    #  TOOLSET: gcc
+    #  CXXSTD: 03,11,14,1z
+    #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    #  ADDPATH: C:\cygwin64\bin;
+    #  TOOLSET: gcc
+    #  CXXSTD: 03,11,14,1z
     # Waiting for https://github.com/boostorg/system/issues/116
     #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
     #  ADDPATH: C:\mingw\bin;
     #  TOOLSET: gcc
     #  CXXSTD: 03,11,14,1z
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      ADDPATH: C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;
-      TOOLSET: gcc
-      CXXSTD: 03,11,14,1z
+    #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    #  ADDPATH: C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;
+    #  TOOLSET: gcc
+    #  CXXSTD: 03,11,14,1z
 
 before_build:
     - set BOOST_BRANCH=develop

--- a/test/appveyor.yml
+++ b/test/appveyor.yml
@@ -61,7 +61,7 @@ before_build:
     - set BOOST=C:/boost-local
     - git clone -b %BOOST_BRANCH% --depth 10 https://github.com/boostorg/boost.git %BOOST%
     - cd %BOOST%
-    - git submodule update --init --depth 10 tools/build tools/boostdep libs/filesystem libs/atomic libs/system libs/interprocess
+    - git submodule update --init --depth 10 tools/build tools/boostdep libs/filesystem libs/atomic libs/system libs/interprocess libs/array
 
     - rm -rf %BOOST%/libs/%BOOST_LIBS_FOLDER%
     - mv -f %APPVEYOR_BUILD_FOLDER% %BOOST%/libs/%BOOST_LIBS_FOLDER%

--- a/test/appveyor.yml
+++ b/test/appveyor.yml
@@ -64,7 +64,7 @@ before_build:
     - git submodule update --init --depth 10 tools/build tools/boostdep
         libs/filesystem libs/atomic libs/system libs/interprocess libs/array
         libs/iterator libs/detail libs/exception libs/smart_ptr libs/mpl
-        libs/align libs/container libs/tuple
+        libs/align libs/container libs/tuple libs/intrusive
 
     - rm -rf %BOOST%/libs/%BOOST_LIBS_FOLDER%
     - mv -f %APPVEYOR_BUILD_FOLDER% %BOOST%/libs/%BOOST_LIBS_FOLDER%

--- a/test/thread_safety_checking.cpp
+++ b/test/thread_safety_checking.cpp
@@ -7,14 +7,13 @@
 #include "test_impl.hpp"
 #include <boost/stacktrace/stacktrace_fwd.hpp>
 
+#include <chrono> 
 #include <sstream>
+#include <thread>
 
 #include <boost/stacktrace.hpp>
-#include <boost/thread.hpp>
 #include <boost/optional.hpp>
 #include <boost/core/lightweight_test.hpp>
-
-#include <boost/timer/timer.hpp>
 
 using boost::stacktrace::stacktrace;
 
@@ -42,16 +41,20 @@ void main_test_loop() {
 }
 
 int main() {
-    boost::timer::auto_cpu_timer t;
+    const auto t = std::chrono::steady_clock::now();
 
-    boost::thread t1(main_test_loop);
-    boost::thread t2(main_test_loop);
-    boost::thread t3(main_test_loop);
+    std::thread t1(main_test_loop);
+    std::thread t2(main_test_loop);
+    std::thread t3(main_test_loop);
     main_test_loop();
 
     t1.join();
     t2.join();
     t3.join();
 
+    const auto elapsed = t - std::chrono::steady_clock::now();
+    std::cout << "Elapsed: " << std::chrono::duration_cast<std::chrono::milliseconds>(
+        elapsed
+    ). count() << "ms";
     return boost::report_errors();
 }


### PR DESCRIPTION
* Update thread_safety_checking.cpp to use Standard Library types
* Remove MinGW runs due to https://github.com/boostorg/system/issues/116
* Delete the shared memory example sources