### PR TITLE
Reduction of included Windows SDK headers

### DIFF
--- a/include/boost/stacktrace/detail/frame_msvc.ipp
+++ b/include/boost/stacktrace/detail/frame_msvc.ipp
@@ -18,7 +18,17 @@
 #include <boost/core/noncopyable.hpp>
 #include <boost/stacktrace/detail/to_dec_array.hpp>
 #include <boost/stacktrace/detail/to_hex_array.hpp>
+
+#ifdef WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#else
+// Prevent inclusion of extra Windows SDK headers which can cause conflict
+// with other code using Windows SDK
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#undef WIN32_LEAN_AND_MEAN
+#endif
+
 #include "dbgeng.h"
 
 #include <mutex>


### PR DESCRIPTION
Avoid inclusion of rarely used Windows SDK headers which can cause conflict with other code using Windows SDK.

Refer to issue #155 for example of conflict with Boost.Asio caused by Winsock 1.x header (winsock.h) being included through windows.h in Boost.Stacktrace and conflicting with Winsock 2 header (winsock2.h). Refer to https://github.com/chriskohlhoff/asio/issues/1441 for details.