### PR TITLE
Implement stacktrace from current exception for MSVC

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -140,13 +140,12 @@ lib boost_stacktrace_from_exception
   : # requirements
     <warnings>all
     <target-os>linux:<library>dl
-    <target-os>windows:<build>no  # not supported at the moment
 
     # Command line option to disable build
     <boost.stacktrace.from_exception>off:<build>no
 
     # Require usable libbacktrace on other platforms
-    [ check-target-builds ../build//libbacktrace : : <build>no ]
+    #[ check-target-builds ../build//libbacktrace : : <build>no ]
   : # default build
   : # usage-requirements
     #<link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1

--- a/doc/stacktrace.qbk
+++ b/doc/stacktrace.qbk
@@ -137,7 +137,7 @@ See [link stacktrace.theoretical_async_signal_safety "Theoretical async signal s
 [section Stacktrace from arbitrary exception]
 
 [warning At the moment the functionality is only available for some of the
-         popular C++ runtimes for POSIX systems and requires *libbacktrace*.
+         popular C++ runtimes for POSIX systems with *libbacktrace* and for Windows.
          Make sure that your platform is supported by running some tests.
 ]
 

--- a/include/boost/stacktrace/stacktrace.hpp
+++ b/include/boost/stacktrace/stacktrace.hpp
@@ -33,6 +33,26 @@
 #   pragma warning(disable:2196) // warning #2196: routine is both "inline" and "noinline"
 #endif
 
+#if defined(BOOST_MSVC)
+
+extern "C" {
+
+BOOST_SYMBOL_EXPORT inline void* boost_stacktrace_impl_return_nullptr() { return nullptr; }
+const char* boost_stacktrace_impl_current_exception_stacktrace();
+bool* boost_stacktrace_impl_ref_capture_stacktraces_at_throw();
+
+}
+
+#ifdef _M_IX86
+#   pragma comment(linker, "/ALTERNATENAME:_boost_stacktrace_impl_current_exception_stacktrace=_boost_stacktrace_impl_return_nullptr")
+#   pragma comment(linker, "/ALTERNATENAME:_boost_stacktrace_impl_ref_capture_stacktraces_at_throw=_boost_stacktrace_impl_return_nullptr")
+#else
+#   pragma comment(linker, "/ALTERNATENAME:boost_stacktrace_impl_current_exception_stacktrace=boost_stacktrace_impl_return_nullptr")
+#   pragma comment(linker, "/ALTERNATENAME:boost_stacktrace_impl_ref_capture_stacktraces_at_throw=boost_stacktrace_impl_return_nullptr")
+#endif
+
+#endif
+
 namespace boost { namespace stacktrace {
 
 namespace impl {
@@ -381,6 +401,8 @@ public:
         if (impl::current_exception_stacktrace) {
             trace = impl::current_exception_stacktrace();
         }
+#elif defined(BOOST_MSVC)
+        trace = boost_stacktrace_impl_current_exception_stacktrace();
 #endif
 
         if (trace) {

--- a/include/boost/stacktrace/this_thread.hpp
+++ b/include/boost/stacktrace/this_thread.hpp
@@ -27,6 +27,10 @@ inline void set_capture_stacktraces_at_throw(bool enable = true) noexcept {
     if (impl::ref_capture_stacktraces_at_throw) {
         impl::ref_capture_stacktraces_at_throw() = enable;
     }
+#elif defined(BOOST_MSVC)
+    if (bool* p = boost_stacktrace_impl_ref_capture_stacktraces_at_throw()) {
+        *p = enable;
+    }
 #endif
     (void)enable;
 }
@@ -44,6 +48,10 @@ inline bool get_capture_stacktraces_at_throw() noexcept {
 #if defined(__GNUC__) && defined(__ELF__)
     if (impl::ref_capture_stacktraces_at_throw) {
         return impl::ref_capture_stacktraces_at_throw();
+    }
+#elif defined(BOOST_MSVC)
+    if (bool* p = boost_stacktrace_impl_ref_capture_stacktraces_at_throw()) {
+        return *p;
     }
 #endif
     return false;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -183,17 +183,29 @@ test-suite stacktrace_tests
     [ run test_from_exception_none.cpp : : : $(FORCE_SYMBOL_EXPORT) $(BASIC_DEPS) <debug-symbols>on                 : from_exception_none_basic_ho ]
     [ run test_from_exception_none.cpp : : : $(LINKSHARED_BT) <debug-symbols>on                                     : from_exception_none_bt ]
     [ run test_from_exception_none.cpp : : : <define>BOOST_STACKTRACE_USE_BACKTRACE $(BT_DEPS) <debug-symbols>on    : from_exception_none_bt_ho ]
+    [ run test_from_exception_none.cpp : : : $(LINKSHARED_WIND) <debug-symbols>on                                      : from_exception_none_windbg ]
+    [ run test_from_exception_none.cpp : : : <define>BOOST_STACKTRACE_USE_WINDBG $(WIND_DEPS) <debug-symbols>on        : from_exception_none_windbg_ho ]
+    [ run test_from_exception_none.cpp : : : $(LINKSHARED_WIND_CACHED) <debug-symbols>on                               : from_exception_none_windbg_cached ]
+    [ run test_from_exception_none.cpp : : : <define>BOOST_STACKTRACE_USE_WINDBG_CACHED $(WICA_DEPS) <debug-symbols>on : from_exception_none_windbg_cached_ho ]
 
     [ run test_from_exception_none.cpp : : : <library>/boost/stacktrace//boost_stacktrace_from_exception $(LINKSHARED_BASIC) <debug-symbols>on                       : from_exception_disabled_basic ]
     [ run test_from_exception_none.cpp : : : <library>/boost/stacktrace//boost_stacktrace_from_exception $(FORCE_SYMBOL_EXPORT) $(BASIC_DEPS) <debug-symbols>on      : from_exception_disabled_basic_ho ]
     [ run test_from_exception_none.cpp : : : <library>/boost/stacktrace//boost_stacktrace_from_exception $(LINKSHARED_BT) <debug-symbols>on                          : from_exception_disabled_bt ]
     [ run test_from_exception_none.cpp : : : <library>/boost/stacktrace//boost_stacktrace_from_exception <define>BOOST_STACKTRACE_USE_BACKTRACE $(BT_DEPS)           : from_exception_disabled_bt_ho ]
+    [ run test_from_exception_none.cpp : : : <library>/boost/stacktrace//boost_stacktrace_from_exception $(LINKSHARED_WIND) <debug-symbols>on                                      : from_exception_disabled_windbg ]
+    [ run test_from_exception_none.cpp : : : <library>/boost/stacktrace//boost_stacktrace_from_exception <define>BOOST_STACKTRACE_USE_WINDBG $(WIND_DEPS) <debug-symbols>on        : from_exception_disabled_windbg_ho ]
+    [ run test_from_exception_none.cpp : : : <library>/boost/stacktrace//boost_stacktrace_from_exception $(LINKSHARED_WIND_CACHED) <debug-symbols>on                               : from_exception_disabled_windbg_cached ]
+    [ run test_from_exception_none.cpp : : : <library>/boost/stacktrace//boost_stacktrace_from_exception <define>BOOST_STACKTRACE_USE_WINDBG_CACHED $(WICA_DEPS) <debug-symbols>on : from_exception_disabled_windbg_cached_ho ]
 
     [ link test_from_exception.cpp : <library>/boost/stacktrace//boost_stacktrace_from_exception $(LINKSHARED_BASIC) <debug-symbols>on                                  : from_exception_basic ]
     [ run test_from_exception.cpp : : : <library>/boost/stacktrace//boost_stacktrace_from_exception $(LINKSHARED_BT) <debug-symbols>on                                  : from_exception_bt ]
+    [ run test_from_exception.cpp : : : <library>/boost/stacktrace//boost_stacktrace_from_exception $(LINKSHARED_WIND) <debug-symbols>on                                : from_exception_windbg ]
+    [ run test_from_exception.cpp : : : <library>/boost/stacktrace//boost_stacktrace_from_exception $(LINKSHARED_WIND_CACHED) <debug-symbols>on                         : from_exception_windbg_cached ]
 
     [ link test_from_exception.cpp : <library>/boost/stacktrace//boost_stacktrace_from_exception $(FORCE_SYMBOL_EXPORT) $(BASIC_DEPS) <debug-symbols>on                 : from_exception_basic_ho ]
     [ run test_from_exception.cpp : : : <library>/boost/stacktrace//boost_stacktrace_from_exception <define>BOOST_STACKTRACE_USE_BACKTRACE $(BT_DEPS) <debug-symbols>on : from_exception_bt_ho ]
+    [ run test_from_exception.cpp : : : <library>/boost/stacktrace//boost_stacktrace_from_exception <define>BOOST_STACKTRACE_USE_WINDBG $(WIND_DEPS) <debug-symbols>on        : from_exception_windbg_ho ]
+    [ run test_from_exception.cpp : : : <library>/boost/stacktrace//boost_stacktrace_from_exception <define>BOOST_STACKTRACE_USE_WINDBG_CACHED $(WICA_DEPS) <debug-symbols>on : from_exception_windbg_cached_ho ]
   ;
 
 # Assuring that examples compile and run. Adding sources from `examples` directory to the `type_index` test suite.

--- a/test/test_from_exception.cpp
+++ b/test/test_from_exception.cpp
@@ -31,7 +31,15 @@ BOOST_NOINLINE BOOST_SYMBOL_VISIBLE void in_test_throw_1(const char* msg) {
 
 BOOST_NOINLINE BOOST_SYMBOL_VISIBLE void in_test_throw_2(const char* msg) {
   std::string new_msg{msg};
-  throw std::runtime_error(new_msg);
+  throw std::logic_error(new_msg);
+}
+
+BOOST_NOINLINE BOOST_SYMBOL_VISIBLE void in_test_rethrow_1(const char* msg) {
+  try {
+    in_test_throw_1(msg);
+  } catch (const std::exception&) {
+    throw;
+  }
 }
 
 BOOST_NOINLINE BOOST_SYMBOL_VISIBLE void test_no_exception() {
@@ -62,8 +70,25 @@ BOOST_NOINLINE BOOST_SYMBOL_VISIBLE void test_after_other_exception() {
     auto trace = stacktrace::from_current_exception();
     BOOST_TEST(trace);
     std::cout << "Tarce in test_after_other_exception(): " << trace;
+#if defined(BOOST_MSVC)
+    BOOST_TEST(to_string(trace).find("in_test_throw_1") == std::string::npos);
+    BOOST_TEST(to_string(trace).find("in_test_throw_2") != std::string::npos);
+#else
     BOOST_TEST(to_string(trace).find("in_test_throw_1") != std::string::npos);
     BOOST_TEST(to_string(trace).find("in_test_throw_2") == std::string::npos);
+#endif
+  }
+}
+
+BOOST_NOINLINE BOOST_SYMBOL_VISIBLE void test_rethrow() {
+  try {
+    in_test_rethrow_1("test rethrow");
+  } catch (const std::exception&) {
+    auto trace = stacktrace::from_current_exception();
+    BOOST_TEST(trace);
+    std::cout << "Tarce in test_rethrow(): " << trace << '\n';
+    BOOST_TEST(to_string(trace).find("in_test_throw_1")   != std::string::npos);
+    BOOST_TEST(to_string(trace).find("in_test_rethrow_1") != std::string::npos);
   }
 }
 
@@ -103,7 +128,11 @@ BOOST_NOINLINE BOOST_SYMBOL_VISIBLE void test_rethrow_nested() {
     BOOST_TEST(trace);
     std::cout << "Tarce in test_rethrow_nested(): " << trace << '\n';
     BOOST_TEST(to_string(trace).find("in_test_throw_1") == std::string::npos);
+#if defined(BOOST_MSVC)
+    BOOST_TEST(to_string(trace).find("in_test_throw_2") == std::string::npos);
+#else
     BOOST_TEST(to_string(trace).find("in_test_throw_2") != std::string::npos);
+#endif
   }
 }
 
@@ -133,7 +162,11 @@ BOOST_NOINLINE BOOST_SYMBOL_VISIBLE void test_from_other_thread() {
     BOOST_TEST(trace);
     std::cout << "Tarce in test_rethrow_nested(): " << trace << '\n';
     BOOST_TEST(to_string(trace).find("in_test_throw_1") == std::string::npos);
+#if defined(BOOST_MSVC)
+    BOOST_TEST(to_string(trace).find("in_test_throw_2") == std::string::npos);
+#else
     BOOST_TEST(to_string(trace).find("in_test_throw_2") != std::string::npos);
+#endif
   }
 #endif
 }
@@ -146,6 +179,7 @@ int main() {
   test_no_exception();
   test_trace_from_exception();
   test_after_other_exception();
+  test_rethrow();
   test_nested();
   test_rethrow_nested();
   test_from_other_thread();

--- a/test/test_from_exception.cpp
+++ b/test/test_from_exception.cpp
@@ -42,6 +42,18 @@ BOOST_NOINLINE BOOST_SYMBOL_VISIBLE void in_test_rethrow_1(const char* msg) {
   }
 }
 
+BOOST_NOINLINE BOOST_SYMBOL_VISIBLE void in_test_rethrow_2(const char* msg) {
+  try {
+    in_test_throw_2(msg);
+  } catch (const std::exception&) {
+    try {
+      in_test_throw_1(msg);
+    } catch (const std::exception&) {}
+
+    throw;
+  }
+}
+
 BOOST_NOINLINE BOOST_SYMBOL_VISIBLE void test_no_exception() {
   auto trace = stacktrace::from_current_exception();
   BOOST_TEST(!trace);
@@ -70,13 +82,8 @@ BOOST_NOINLINE BOOST_SYMBOL_VISIBLE void test_after_other_exception() {
     auto trace = stacktrace::from_current_exception();
     BOOST_TEST(trace);
     std::cout << "Tarce in test_after_other_exception(): " << trace;
-#if defined(BOOST_MSVC)
-    BOOST_TEST(to_string(trace).find("in_test_throw_1") == std::string::npos);
-    BOOST_TEST(to_string(trace).find("in_test_throw_2") != std::string::npos);
-#else
     BOOST_TEST(to_string(trace).find("in_test_throw_1") != std::string::npos);
     BOOST_TEST(to_string(trace).find("in_test_throw_2") == std::string::npos);
-#endif
   }
 }
 
@@ -89,6 +96,19 @@ BOOST_NOINLINE BOOST_SYMBOL_VISIBLE void test_rethrow() {
     std::cout << "Tarce in test_rethrow(): " << trace << '\n';
     BOOST_TEST(to_string(trace).find("in_test_throw_1")   != std::string::npos);
     BOOST_TEST(to_string(trace).find("in_test_rethrow_1") != std::string::npos);
+  }
+}
+
+BOOST_NOINLINE BOOST_SYMBOL_VISIBLE void test_rethrow_after_other_exception() {
+  try {
+    in_test_rethrow_2("test_rethrow_after_other_exception");
+  } catch (const std::exception&) {
+    auto trace = stacktrace::from_current_exception();
+    BOOST_TEST(trace);
+    std::cout << "Tarce in test_rethrow_after_other_exception(): " << trace << '\n';
+    BOOST_TEST(to_string(trace).find("in_test_throw_1")   == std::string::npos);
+    BOOST_TEST(to_string(trace).find("in_test_throw_2")   != std::string::npos);
+    BOOST_TEST(to_string(trace).find("in_test_rethrow_2") != std::string::npos);
   }
 }
 
@@ -180,6 +200,7 @@ int main() {
   test_trace_from_exception();
   test_after_other_exception();
   test_rethrow();
+  test_rethrow_after_other_exception();
   test_nested();
   test_rethrow_nested();
   test_from_other_thread();


### PR DESCRIPTION
Original stacktrace from `std::exception_ptr` is not possible currently. `std::current_exception()` makes a copy of current exception object into returned `std::exception_ptr`. So the tracking of the original exception object and its stacktrace are lost.

Support for nested exceptions ~is not much meaningful IMO, it~ complicates the implementation (see the last commit). Without nested exceptions support, one can always get stacktrace from current exception immediately after entering `catch` block, **but it loses the original stacktrace for `rethrow_after_other_exception` case**.

The exception object is destroyed by `__DestructExceptionObject` exported from `vcruntime.dll`, there is no simple way to cleanup stored traces in time unless override `__DestructExceptionObject`.