### PR TITLE
Avoiding -ldl linking when using -DBOOST_STACKTRACE_USE_ADDR2LINE

### DIFF
--- a/include/boost/stacktrace/detail/frame_unwind.ipp
+++ b/include/boost/stacktrace/detail/frame_unwind.ipp
@@ -89,7 +89,7 @@ std::string frame::name() const {
         return std::string();
     }
 
-#if !defined(BOOST_WINDOWS) && !defined(__CYGWIN__)
+#if !defined(BOOST_WINDOWS) && !defined(__CYGWIN__) && !defined(BOOST_STACKTRACE_USE_ADDR2LINE)
     ::Dl_info dli;
     const bool dl_ok = !!::dladdr(const_cast<void*>(addr_), &dli); // `dladdr` on Solaris accepts nonconst addresses
     if (dl_ok && dli.dli_sname) {

--- a/include/boost/stacktrace/detail/location_from_symbol.hpp
+++ b/include/boost/stacktrace/detail/location_from_symbol.hpp
@@ -28,9 +28,15 @@ public:
     explicit location_from_symbol(const void* addr) noexcept
         : dli_()
     {
+	#if !defined(BOOST_STACKTRACE_USE_ADDR2LINE) 
         if (!::dladdr(const_cast<void*>(addr), &dli_)) { // `dladdr` on Solaris accepts nonconst addresses
             dli_.dli_fname = 0;
         }
+	#else 
+        
+	dli_.dli_fname = 0;
+	
+	#endif
     }
 
     bool empty() const noexcept {


### PR DESCRIPTION
While using `addr2line` binary to get the symbolic function information from address. We Fork and execute command in the child process. But currently, it requires unnecessarily linking Dynamic Loader (-ldl).

Changed the code to avoid that linking.