### PR TITLE
Add a conditional rule for enabling boost_stacktrace_from_exception. …

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -6,6 +6,7 @@
 #
 
 import feature ;
+import property ;
 import ../../config/checks/config : requires ;
 
 project
@@ -134,6 +135,22 @@ lib boost_stacktrace_windbg_cached
     #<link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
   ;
 
+rule build-stacktrace-from-exception ( props * )
+{
+    local enabled = [ property.select <boost.stacktrace.from_exception> : $(props) ] ;
+    switch $(enabled:G=)
+    {
+        case  "on" :  return ;
+        case "off" :  return <build>no ;
+    }
+
+    local arch = [ property.select <architecture> : $(props) ] ;
+    if $(arch) && ( $(arch:G=) != x86 )
+    {
+        return <build>no ;
+    }
+}
+
 lib boost_stacktrace_from_exception
   : # sources
     ../src/from_exception.cpp
@@ -141,8 +158,8 @@ lib boost_stacktrace_from_exception
     <warnings>all
     <target-os>linux:<library>dl
 
-    # Command line option to disable build
-    <boost.stacktrace.from_exception>off:<build>no
+    # Enable build when explicitly requested, or by default, when on x86
+    <conditional>@build-stacktrace-from-exception
 
     # Require usable libbacktrace on other platforms
     #[ check-target-builds ../build//libbacktrace : : <build>no ]


### PR DESCRIPTION
…Fixes #165.

As explained in #165, boost_stacktrace_from_exception doesn't build under macos-14, which breaks CI. Since https://github.com/boostorg/stacktrace/issues/163 claims that it never builds on non-x86 architectures, this PR changes build/Jamfile to only build boost_stacktrace_from_exception by default when the architecture is x86. The feature `boost.stacktrace.from_exception` can still be used to override the default, in both directions.