### PR TITLE
Fix type conversions errors reported by GCC

### DIFF
--- a/include/boost/stacktrace/detail/addr2line_impls.hpp
+++ b/include/boost/stacktrace/detail/addr2line_impls.hpp
@@ -123,8 +123,8 @@ inline std::string addr2line(const char* flag, const void* addr) {
         res = loc.name();
     } else {
         res.resize(16);
-        int rlin_size = ::readlink("/proc/self/exe", &res[0], res.size() - 1);
-        while (rlin_size == static_cast<int>(res.size() - 1)) {
+        ssize_t rlin_size = ::readlink("/proc/self/exe", &res[0], res.size() - 1);
+        while (rlin_size == static_cast<ssize_t>(res.size() - 1)) {
             res.resize(res.size() * 4);
             rlin_size = ::readlink("/proc/self/exe", &res[0], res.size() - 1);
         }
@@ -132,7 +132,7 @@ inline std::string addr2line(const char* flag, const void* addr) {
             res.clear();
             return res;
         }
-        res.resize(rlin_size);
+        res.resize(static_cast<std::size_t>(rlin_size));
     }
 
     addr2line_pipe p(flag, res.c_str(), to_hex_array(addr).data());

--- a/include/boost/stacktrace/detail/collect_unwind.ipp
+++ b/include/boost/stacktrace/detail/collect_unwind.ipp
@@ -88,7 +88,7 @@ std::size_t this_thread_frames::collect(native_frame_ptr_t* out_frames, std::siz
 #else
     boost::stacktrace::detail::unwind_state state = { skip, out_frames, out_frames + max_frames_count };
     ::_Unwind_Backtrace(&boost::stacktrace::detail::unwind_callback, &state);
-    frames_count = state.current - out_frames;
+    frames_count = static_cast<std::size_t>(state.current - out_frames);
 #endif //defined(BOOST_STACKTRACE_USE_LIBC_BACKTRACE_FUNCTION)
 
     if (frames_count && out_frames[frames_count - 1] == 0) {

--- a/include/boost/stacktrace/detail/libbacktrace_impls.hpp
+++ b/include/boost/stacktrace/detail/libbacktrace_impls.hpp
@@ -52,7 +52,7 @@ inline int libbacktrace_full_callback(void *data, uintptr_t /*pc*/, const char *
     if (d.function && function) {
         *d.function = function;
     }
-    d.line = lineno;
+    d.line = static_cast<std::size_t>(lineno);
     return 0;
 }
 


### PR DESCRIPTION
This commit fixes errors when compiling with:
 -Wall -Werror -Wextra -Wconversion -Wsign-conversion
