### PR TITLE
Fix missing include for std::exception

### DIFF
--- a/src/from_exception.cpp
+++ b/src/from_exception.cpp
@@ -157,6 +157,7 @@ BOOST_SYMBOL_EXPORT void assert_no_pending_traces() noexcept {
 #include <boost/stacktrace/safe_dump_to.hpp>
 
 #include <cstddef>
+#include <exception>
 #include <dlfcn.h>
 
 #if !BOOST_STACKTRACE_ALWAYS_STORE_IN_PADDING


### PR DESCRIPTION
Fixes build on mingw: 
from_exception.cpp:333:23: error: 'current_exception' is not a member of 'std'

/cc @apolukhin from #147