### PR TITLE
Fix build on mingw

### DIFF
--- a/src/from_exception.cpp
+++ b/src/from_exception.cpp
@@ -4,7 +4,7 @@
 // accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-#if defined(_MSC_VER)
+#if defined(_WIN32)
 
 #include <boost/stacktrace/safe_dump_to.hpp>
 #include <windows.h>


### PR DESCRIPTION
Fixes build on mingw where the posix/dlsym path will fail to build even if a dlfcn wrapper is provided , its simpler to just use the msvc path for all windows targets

/cc @apolukhin from #147