### PR TITLE
[doc] fix missing namespace/class in example

### DIFF
--- a/doc/stacktrace.qbk
+++ b/doc/stacktrace.qbk
@@ -163,7 +163,7 @@ int main() {
     foo("test1");
     bar("test2");
   } catch (const std::exception& exc) {
-    boost::stacktrace::stacktrace trace = boost::stacktrace::from_current_exception();  // <---
+    boost::stacktrace::stacktrace trace = boost::stacktrace::stacktrace::from_current_exception();  // <---
     std::cerr << "Caught exception: " << exc.what() << ", trace:\n" << trace;
   }
 }


### PR DESCRIPTION
Please backport/merge this fix to previous versions with this example as well :)