### PR TITLE
Don't export boost_stacktrace_impl_return_nullptr for static build

### DIFF
--- a/include/boost/stacktrace/frame.hpp
+++ b/include/boost/stacktrace/frame.hpp
@@ -20,6 +20,20 @@
 #include <boost/stacktrace/detail/frame_decl.hpp>
 #include <boost/stacktrace/detail/push_options.h>
 
+#if defined(BOOST_MSVC) && (defined(BOOST_STACKTRACE_INTERNAL_BUILD_LIBS) || !defined(BOOST_STACKTRACE_LINK))
+extern "C" {
+
+#if defined(BOOST_STACKTRACE_DYN_LINK)
+BOOST_SYMBOL_EXPORT
+#elif defined(BOOST_STACKTRACE_LINK)
+#else
+BOOST_SYMBOL_EXPORT inline
+#endif
+void* boost_stacktrace_impl_return_nullptr() { return nullptr; }
+
+}
+#endif
+
 namespace boost { namespace stacktrace {
 
 /// Comparison operators that provide platform dependant ordering and have O(1) complexity; are Async-Handler-Safe.

--- a/include/boost/stacktrace/stacktrace.hpp
+++ b/include/boost/stacktrace/stacktrace.hpp
@@ -37,10 +37,6 @@
 
 extern "C" {
 
-//#if defined(BOOST_STACKTRACE_LINK) && defined(BOOST_STACKTRACE_DYN_LINK)
-BOOST_SYMBOL_EXPORT
-//#endif
-inline void* boost_stacktrace_impl_return_nullptr() { return nullptr; }
 const char* boost_stacktrace_impl_current_exception_stacktrace();
 bool* boost_stacktrace_impl_ref_capture_stacktraces_at_throw();
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -188,6 +188,8 @@ test-suite stacktrace_tests
     [ run test_void_ptr_cast.cpp ]
     [ run test_num_conv.cpp ]
 
+    [ run test_from_exception_none.cpp : : : $(LINKSHARED_NOOP) <debug-symbols>on                                   : from_exception_none_noop ]
+    [ run test_from_exception_none.cpp : : : <define>BOOST_STACKTRACE_USE_NOOP $(NOOP_DEPS) <debug-symbols>on       : from_exception_none_noop_ho ]
     [ run test_from_exception_none.cpp : : : $(LINKSHARED_BASIC) <debug-symbols>on                                  : from_exception_none_basic ]
     [ run test_from_exception_none.cpp : : : $(FORCE_SYMBOL_EXPORT) $(BASIC_DEPS) <debug-symbols>on                 : from_exception_none_basic_ho ]
     [ run test_from_exception_none.cpp : : : $(LINKSHARED_BT) <debug-symbols>on                                     : from_exception_none_bt ]
@@ -197,6 +199,8 @@ test-suite stacktrace_tests
     [ run test_from_exception_none.cpp : : : $(LINKSHARED_WIND_CACHED) <debug-symbols>on                               : from_exception_none_windbg_cached ]
     [ run test_from_exception_none.cpp : : : <define>BOOST_STACKTRACE_USE_WINDBG_CACHED $(WICA_DEPS) <debug-symbols>on : from_exception_none_windbg_cached_ho ]
 
+    [ run test_from_exception_none.cpp : : : <library>/boost/stacktrace//boost_stacktrace_from_exception $(LINKSHARED_NOOP) <debug-symbols>on                        : from_exception_disabled_none ]
+    [ run test_from_exception_none.cpp : : : <library>/boost/stacktrace//boost_stacktrace_from_exception <define>BOOST_STACKTRACE_USE_NOOP $(NOOP_DEPS)              : from_exception_disabled_none_ho ]
     [ run test_from_exception_none.cpp : : : <library>/boost/stacktrace//boost_stacktrace_from_exception $(LINKSHARED_BASIC) <debug-symbols>on                       : from_exception_disabled_basic ]
     [ run test_from_exception_none.cpp : : : <library>/boost/stacktrace//boost_stacktrace_from_exception $(FORCE_SYMBOL_EXPORT) $(BASIC_DEPS) <debug-symbols>on      : from_exception_disabled_basic_ho ]
     [ run test_from_exception_none.cpp : : : <library>/boost/stacktrace//boost_stacktrace_from_exception $(LINKSHARED_BT) <debug-symbols>on                          : from_exception_disabled_bt ]


### PR DESCRIPTION
Now `boost_stacktrace.lib` provides the symbol `boost_stacktrace_impl_return_nullptr` for static and shared build.

For header only library, to make the symbol available **automatically**, the only way AFAIK is to export it. We may also consider provide a configuration macro to opt-out the exported symbol, and user need to manually define the non-exported symbol somewhere in their binaries.

Closes #177 .