### PR TITLE
Use Relative Virtual Addresses to allow their decoding without knowing the base address

### DIFF
--- a/include/boost/stacktrace/detail/addr_base_msvc.hpp
+++ b/include/boost/stacktrace/detail/addr_base_msvc.hpp
@@ -1,0 +1,59 @@
+// Copyright Antony Polukhin, 2016-2024.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_STACKTRACE_DETAIL_ADDR_BASE_MSVC_HPP
+#define BOOST_STACKTRACE_DETAIL_ADDR_BASE_MSVC_HPP
+
+#include <boost/config.hpp>
+#ifdef BOOST_HAS_PRAGMA_ONCE
+#   pragma once
+#endif
+
+#ifdef WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <psapi.h>
+#else
+// Prevent inclusion of extra Windows SDK headers which can cause conflict
+// with other code using Windows SDK
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <psapi.h>
+#undef WIN32_LEAN_AND_MEAN
+#endif
+
+namespace boost { namespace stacktrace { namespace detail {
+  inline  uintptr_t get_own_proc_addr_base(const void* addr) {
+        HANDLE processHandle = GetCurrentProcess();
+        HMODULE modules[1024];
+        
+        DWORD needed;
+
+        if (EnumProcessModulesEx(processHandle, modules, sizeof(modules), &needed, LIST_MODULES_ALL)) {
+            int moduleCount = needed / sizeof(HMODULE);
+
+            for (int i = 0; i < moduleCount; ++i) {
+                MODULEINFO moduleInfo;
+                TCHAR moduleName[MAX_PATH];
+
+                // Get the module name
+                if (GetModuleBaseName(processHandle, modules[i], moduleName, sizeof(moduleName) / sizeof(TCHAR))) {
+                    // Get module information
+                    if (GetModuleInformation(processHandle, modules[i], &moduleInfo, sizeof(moduleInfo))) {
+                        if (moduleInfo.lpBaseOfDll <= addr && addr < LPBYTE(moduleInfo.lpBaseOfDll) + moduleInfo.SizeOfImage) {
+                            // Module contains the address
+                            return reinterpret_cast<uintptr_t>(moduleInfo.lpBaseOfDll);
+                        }
+                    }
+                }
+            }
+        }
+
+        return 0;
+    }
+
+}}} // namespace boost::stacktrace::detail
+
+#endif // BOOST_STACKTRACE_DETAIL_ADDR_BASE_MSVC_HPP

--- a/include/boost/stacktrace/detail/addr_base_msvc.hpp
+++ b/include/boost/stacktrace/detail/addr_base_msvc.hpp
@@ -1,3 +1,5 @@
+// Copyright Antony Polukhin, 2016-2024.
+//
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)

--- a/include/boost/stacktrace/detail/frame_msvc.ipp
+++ b/include/boost/stacktrace/detail/frame_msvc.ipp
@@ -19,13 +19,22 @@
 #include <boost/stacktrace/detail/to_dec_array.hpp>
 #include <boost/stacktrace/detail/to_hex_array.hpp>
 
+//Testing
+#define BOOST_STACKTRACE_OFFSET_ADDR_BASE
+
 #ifdef WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#   ifdef BOOST_STACKTRACE_OFFSET_ADDR_BASE
+#include <psapi.h>
+#   endif
 #else
 // Prevent inclusion of extra Windows SDK headers which can cause conflict
 // with other code using Windows SDK
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#   ifdef BOOST_STACKTRACE_OFFSET_ADDR_BASE
+#include <psapi.h>
+#   endif
 #undef WIN32_LEAN_AND_MEAN
 #endif
 
@@ -381,6 +390,36 @@ public:
         return result;
     }
 
+#ifdef BOOST_STACKTRACE_OFFSET_ADDR_BASE
+    const uintptr_t get_module_base_impl(const void* addr) const {
+        HANDLE processHandle = GetCurrentProcess();
+        HMODULE modules[1024];
+        
+        DWORD needed;
+
+        if (EnumProcessModulesEx(processHandle, modules, sizeof(modules), &needed, LIST_MODULES_ALL)) {
+            int moduleCount = needed / sizeof(HMODULE);
+
+            for (int i = 0; i < moduleCount; ++i) {
+                MODULEINFO moduleInfo;
+                TCHAR moduleName[MAX_PATH];
+
+                // Get the module name
+                if (GetModuleBaseName(processHandle, modules[i], moduleName, sizeof(moduleName) / sizeof(TCHAR))) {
+                    // Get module information
+                    if (GetModuleInformation(processHandle, modules[i], &moduleInfo, sizeof(moduleInfo))) {
+                        if (moduleInfo.lpBaseOfDll <= addr && addr < LPBYTE(moduleInfo.lpBaseOfDll) + moduleInfo.SizeOfImage) {
+                            // Module contains the address
+                            return reinterpret_cast<uintptr_t>(moduleInfo.lpBaseOfDll);
+                        }
+                    }
+                }
+            }
+        }
+
+        return 0;
+    }
+#endif
     void to_string_impl(const void* addr, std::string& res) const {
         if (!is_inited()) {
             return;
@@ -390,8 +429,23 @@ public:
         std::string name = this->get_name_impl(addr, &module_name);
         if (!name.empty()) {
             res += name;
+            // const uintptr_t base_addr = get_module_base_impl(addr);
+            // res  += '(';
+            // res += to_hex_array(reinterpret_cast<uintptr_t>(addr) - base_addr).data();
+            // res += '-';
+            // res += to_hex_array(base_addr).data();
+            // res += ')';
         } else {
+#ifdef BOOST_STACKTRACE_OFFSET_ADDR_BASE
+            // Get own base address
+            const uintptr_t base_addr = get_module_base_impl(addr);
+            res += to_hex_array(reinterpret_cast<uintptr_t>(addr) - base_addr).data();
+            // res += '+';
+            // res += to_hex_array(base_addr).data();
+            // res += ')';
+#else
             res += to_hex_array(addr).data();
+#endif
         }
 
         std::pair<std::string, std::size_t> source_line = this->get_source_file_line_impl(addr);

--- a/include/boost/stacktrace/detail/frame_msvc.ipp
+++ b/include/boost/stacktrace/detail/frame_msvc.ipp
@@ -19,26 +19,17 @@
 #include <boost/stacktrace/detail/to_dec_array.hpp>
 #include <boost/stacktrace/detail/to_hex_array.hpp>
 
-//Testing
-#define BOOST_STACKTRACE_OFFSET_ADDR_BASE
-
-#ifdef BOOST_STACKTRACE_OFFSET_ADDR_BASE
+#ifndef BOOST_STACKTRACE_DISABLE_OFFSET_ADDR_BASE
 #include <boost/stacktrace/detail/addr_base_msvc.hpp>
 #endif
 
 #ifdef WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#   ifdef BOOST_STACKTRACE_OFFSET_ADDR_BASE
-#include <psapi.h>
-#   endif
 #else
 // Prevent inclusion of extra Windows SDK headers which can cause conflict
 // with other code using Windows SDK
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#   ifdef BOOST_STACKTRACE_OFFSET_ADDR_BASE
-#include <psapi.h>
-#   endif
 #undef WIN32_LEAN_AND_MEAN
 #endif
 
@@ -404,12 +395,12 @@ public:
         if (!name.empty()) {
             res += name;
         } else {
-#ifdef BOOST_STACKTRACE_OFFSET_ADDR_BASE
+#ifdef BOOST_STACKTRACE_DISABLE_OFFSET_ADDR_BASE
+            res += to_hex_array(addr).data();
+#else
             // Get own base address
             const uintptr_t base_addr = get_own_proc_addr_base(addr);
             res += to_hex_array(reinterpret_cast<uintptr_t>(addr) - base_addr).data();
-#else
-            res += to_hex_array(addr).data();
 #endif
         }
 

--- a/include/boost/stacktrace/detail/frame_unwind.ipp
+++ b/include/boost/stacktrace/detail/frame_unwind.ipp
@@ -17,6 +17,7 @@
 #include <boost/stacktrace/detail/to_hex_array.hpp>
 #include <boost/stacktrace/detail/location_from_symbol.hpp>
 #include <boost/stacktrace/detail/to_dec_array.hpp>
+#include <boost/stacktrace/detail/addr_base.hpp>
 #include <boost/core/demangle.hpp>
 
 #include <cstdio>
@@ -40,7 +41,8 @@ public:
         if (!Base::res.empty()) {
             Base::res = boost::core::demangle(Base::res.c_str());
         } else {
-            Base::res = to_hex_array(addr).data();
+            auto addr_base = boost::stacktrace::detail::get_own_proc_addr_base(addr);
+            Base::res = to_hex_array(reinterpret_cast<uintptr_t>(addr) - addr_base).data();
         }
 
         if (Base::prepare_source_location(addr)) {

--- a/include/boost/stacktrace/detail/frame_unwind.ipp
+++ b/include/boost/stacktrace/detail/frame_unwind.ipp
@@ -30,6 +30,9 @@
 #   include <boost/stacktrace/detail/unwind_base_impls.hpp>
 #endif
 
+//Testing
+#define BOOST_STACKTRACE_OFFSET_ADDR_BASE
+
 namespace boost { namespace stacktrace { namespace detail {
 
 template <class Base>
@@ -41,8 +44,12 @@ public:
         if (!Base::res.empty()) {
             Base::res = boost::core::demangle(Base::res.c_str());
         } else {
-            auto addr_base = boost::stacktrace::detail::get_own_proc_addr_base(addr);
+#ifdef BOOST_STACKTRACE_OFFSET_ADDR_BASE
+            const auto addr_base = boost::stacktrace::detail::get_own_proc_addr_base(addr);
             Base::res = to_hex_array(reinterpret_cast<uintptr_t>(addr) - addr_base).data();
+#else
+            Base::res = to_hex_array(addr).data();
+#endif
         }
 
         if (Base::prepare_source_location(addr)) {

--- a/include/boost/stacktrace/detail/frame_unwind.ipp
+++ b/include/boost/stacktrace/detail/frame_unwind.ipp
@@ -30,9 +30,6 @@
 #   include <boost/stacktrace/detail/unwind_base_impls.hpp>
 #endif
 
-//Testing
-#define BOOST_STACKTRACE_OFFSET_ADDR_BASE
-
 namespace boost { namespace stacktrace { namespace detail {
 
 template <class Base>
@@ -44,11 +41,11 @@ public:
         if (!Base::res.empty()) {
             Base::res = boost::core::demangle(Base::res.c_str());
         } else {
-#ifdef BOOST_STACKTRACE_OFFSET_ADDR_BASE
+#ifdef BOOST_STACKTRACE_DISABLE_OFFSET_ADDR_BASE
+            Base::res = to_hex_array(addr).data();
+#else
             const auto addr_base = boost::stacktrace::detail::get_own_proc_addr_base(addr);
             Base::res = to_hex_array(reinterpret_cast<uintptr_t>(addr) - addr_base).data();
-#else
-            Base::res = to_hex_array(addr).data();
 #endif
         }
 


### PR DESCRIPTION
Instead of printing absolute addresses use relative ones so they can be used later to decode the stack trace.

## Motivation

It’s quite common to release apps without debug symbols while keeping them internally. Currently the lib prints absolute addresses which require the base address to decode them using symbols. With this change, the base address won’t be needed as values are relative to the beginning of the loaded module/binary.

The implementation for unix is **straightforward** as the existing code is used. For Windows, I’ve implemented similar logic using Windows API.

## Manual testing of Windows implementation

Here are 2 runs of `trivial_windbg_lib.exe` with .pdb and without .pdb file:

```jsx
>./trivial_windbg_lib.exe
 0# boost::stacktrace::basic_stacktrace<std::allocator<boost::stacktrace::frame> >::init at C:\Users\czarneckim\repositories\boost\boost\stacktrace\stacktrace.hpp:110
 1# main at C:\Users\czarneckim\repositories\boost\libs\stacktrace\test\test_trivial.cpp:14
 2# __scrt_common_main_seh at D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
 3# BaseThreadInitThunk in C:\WINDOWS\System32\KERNEL32.DLL
 4# RtlUserThreadStart in C:\WINDOWS\SYSTEM32\ntdll.dll

> mv ./trivial_windbg_lib.pdb{,_} 
> ./trivial_windbg_lib.exe
 0# 0x0000000000001DE3 in C:\Users\czarneckim\repositories\boost\bin.v2\libs\stacktrace\test\trivial_windbg_lib.test\msvc-14.3\release\x86_64\asynch-exceptions-on\cxxstd-latest-iso\debug-symbols-on\threading-multi\trivial_windbg_lib.exe
 1# 0x0000000000001FEE in C:\Users\czarneckim\repositories\boost\bin.v2\libs\stacktrace\test\trivial_windbg_lib.test\msvc-14.3\release\x86_64\asynch-exceptions-on\cxxstd-latest-iso\debug-symbols-on\threading-multi\trivial_windbg_lib.exe
 2# 0x000000000000246C in C:\Users\czarneckim\repositories\boost\bin.v2\libs\stacktrace\test\trivial_windbg_lib.test\msvc-14.3\release\x86_64\asynch-exceptions-on\cxxstd-latest-iso\debug-symbols-on\threading-multi\trivial_windbg_lib.exe
 3# BaseThreadInitThunk in C:\WINDOWS\System32\KERNEL32.DLL
 4# RtlUserThreadStart in C:\WINDOWS\SYSTEM32\ntdll.dll

> mv ./trivial_windbg_lib.pdb{_,}
> winaddr2line.exe -f -e trivial_windbg_lib.pdb 0x0000000000001DE3
boost::stacktrace::basic_stacktrace<std::allocator<boost::stacktrace::frame> >::init
C:\Users\czarneckim\repositories\boost\boost\stacktrace\stacktrace.hpp:110
```

I’ve also decoded the returned address using x64dbg running `trivial_windbg_lib.exe+0x0000000000001DE3`:

![image](https://github.com/user-attachments/assets/a36d3306-488d-4610-9f04-7888b98c2b75)

## Control

As it was suggested in #180, the new logic is enabled by default, but can be disabled with `BOOST_STACKTRACE_DISABLE_OFFSET_ADDR_BASE` (With non header-only mode, it requires rebuilding the lib)

## Further work

If the implementation would be accepted, I’m happy to do the rest of work, like changes in documentation or test cases. It’s my first contribution to this repo, so I would be very grateful for some guidance what is required.