### PR TITLE
Expose stacktrace libraries as build features

### DIFF
--- a/boost-stacktrace-features.jam
+++ b/boost-stacktrace-features.jam
@@ -6,4 +6,10 @@
 #
 import feature ;
 
+feature.feature boost.stacktrace.noop : on off : optional propagated ;
+feature.feature boost.stacktrace.backtrace : on off : optional propagated ;
+feature.feature boost.stacktrace.addr2line : on off : optional propagated ;
+feature.feature boost.stacktrace.basic : on off : optional propagated ;
+feature.feature boost.stacktrace.windbg : on off : optional propagated ;
+feature.feature boost.stacktrace.windbg_cached : on off : optional propagated ;
 feature.feature boost.stacktrace.from_exception : on off : optional propagated ;

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -11,6 +11,12 @@ import boost-stacktrace-features ;
 import config : requires ;
 import property ;
 
+constant stacktrace_common_requirements :
+    <warnings>all
+    <link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
+    <define>BOOST_STACKTRACE_NO_LIB=1
+    ;
+
 constant boost_dependencies_private :
     <library>/boost/assert//boost_assert
     ;
@@ -63,87 +69,108 @@ explicit WinDbg ;
 mp-run-simple has_windbg_cached.cpp : : : <library>Dbgeng <library>ole32 : WinDbgCached ;
 explicit WinDbgCached ;
 
+rule build-stacktrace-feature ( name : props * )
+{
+    local enabled = [ property.select <boost.stacktrace.$(name)> : $(props) ] ;
+    switch $(enabled:G=)
+    {
+        case  "on" :  return ;
+        case "off" :  return <build>no ;
+    }
+}
+
 lib boost_stacktrace_noop
   : # sources
     ../src/noop.cpp
   : # requirements
-    <warnings>all
-    <link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
+    $(stacktrace_common_requirements)
+    # Enable build when explicitly requested
+    <conditional>@$(build-stacktrace-feature noop)
   : # default build
   : # usage-requirements
     #<link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
-    <define>BOOST_STACKTRACE_NO_LIB=1
   ;
 
 lib boost_stacktrace_backtrace
   : # sources
     ../src/backtrace.cpp
   : # requirements
-    <warnings>all
+    $(stacktrace_common_requirements)
     <target-os>linux:<library>dl
     <library>backtrace
-    <link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
     [ check-target-builds libbacktrace : : <build>no ]
+    <conditional>@$(build-stacktrace-feature backtrace)
   : # default build
   : # usage-requirements
     #<link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
-    <define>BOOST_STACKTRACE_NO_LIB=1
   ;
+
+rule build-stacktrace-addr2line ( props * )
+{
+    local enabled = [ property.select <boost.stacktrace.addr2line> : $(props) ] ;
+    switch $(enabled:G=)
+    {
+        case  "on" :  return ;
+        case "off" :  return <build>no ;
+    }
+
+    # Disable by default on Windows when not using Cygwin
+    if <target-os>windows in $(props) && ! ( <target-os>cygwin in $(props) )
+    {
+        return <build>no ;
+    }
+}
 
 lib boost_stacktrace_addr2line
   : # sources
     ../src/addr2line.cpp
   : # requirements
-    <warnings>all
+    $(stacktrace_common_requirements)
     <target-os>linux:<library>dl
-    <link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
     [ check-target-builds addr2line : : <build>no ]
+    <conditional>@build-stacktrace-addr2line
   : # default build
   : # usage-requirements
     #<link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
-    <define>BOOST_STACKTRACE_NO_LIB=1
   ;
 
 lib boost_stacktrace_basic
   : # sources
     ../src/basic.cpp
   : # requirements
-    <warnings>all
+    $(stacktrace_common_requirements)
     <target-os>linux:<library>dl
-    <link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
     [ check-target-builds WinDbg : <build>no ]
+    <conditional>@$(build-stacktrace-feature basic)
   : # default build
   : # usage-requirements
     #<link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
-    <define>BOOST_STACKTRACE_NO_LIB=1
   ;
 
 lib boost_stacktrace_windbg
   : # sources
     ../src/windbg.cpp
   : # requirements
-    <warnings>all
+    $(stacktrace_common_requirements)
     <library>Dbgeng <library>ole32
-    <link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
     [ check-target-builds WinDbg : : <build>no ]
+    <conditional>@$(build-stacktrace-feature windbg)
   : # default build
   : # usage-requirements
     #<link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
-    <define>BOOST_STACKTRACE_NO_LIB=1
   ;
 
 lib boost_stacktrace_windbg_cached
   : # sources
     ../src/windbg_cached.cpp
   : # requirements
-    <warnings>all
+    $(stacktrace_common_requirements)
     <library>Dbgeng <library>ole32
-    <link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
     [ check-target-builds WinDbgCached : : <build>no ]
+    <conditional>@$(build-stacktrace-feature windbg-cached)
   : # default build
   : # usage-requirements
     #<link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
-    <define>BOOST_STACKTRACE_NO_LIB=1
   ;
 
 rule build-stacktrace-from-exception ( props * )
@@ -166,7 +193,7 @@ lib boost_stacktrace_from_exception
   : # sources
     ../src/from_exception.cpp
   : # requirements
-    <warnings>all
+    $(stacktrace_common_requirements)
     <target-os>linux:<library>dl
 
     # Enable build when explicitly requested, or by default, when on x86
@@ -177,5 +204,4 @@ lib boost_stacktrace_from_exception
   : # default build
   : # usage-requirements
     #<link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
-    <define>BOOST_STACKTRACE_NO_LIB=1
   ;

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -91,8 +91,7 @@ lib boost_stacktrace_backtrace
   : # sources
     ../src/backtrace.cpp
   : # requirements
-  <warnings>all
-    $(stacktrace_common_requirements)
+    <warnings>all
     <target-os>linux:<library>dl
     <library>backtrace
     <link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
@@ -158,7 +157,7 @@ lib boost_stacktrace_windbg
     <library>Dbgeng <library>ole32
     <link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
     [ check-target-builds WinDbg : : <build>no ]
-    [ build-stacktrace-feature windbg ]
+    <conditional>@$(build-stacktrace-feature windbg)
   : # default build
   : # usage-requirements
     #<link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
@@ -173,7 +172,7 @@ lib boost_stacktrace_windbg_cached
     <library>Dbgeng <library>ole32
     <link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
     [ check-target-builds WinDbgCached : : <build>no ]
-    [ build-stacktrace-feature windbg-cached ]
+    <conditional>@$(build-stacktrace-feature windbg-cached)
   : # default build
   : # usage-requirements
     #<link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -11,12 +11,6 @@ import boost-stacktrace-features ;
 import config : requires ;
 import property ;
 
-constant stacktrace_common_requirements :
-    <warnings>all
-    <link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
-    <define>BOOST_STACKTRACE_NO_LIB=1
-    ;
-
 constant boost_dependencies_private :
     <library>/boost/assert//boost_assert
     ;
@@ -83,26 +77,31 @@ lib boost_stacktrace_noop
   : # sources
     ../src/noop.cpp
   : # requirements
-    $(stacktrace_common_requirements)
+    <warnings>all
+    <link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
     # Enable build when explicitly requested
     <conditional>@$(build-stacktrace-feature noop)
   : # default build
   : # usage-requirements
     #<link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
+    <define>BOOST_STACKTRACE_NO_LIB=1
   ;
 
 lib boost_stacktrace_backtrace
   : # sources
     ../src/backtrace.cpp
   : # requirements
+  <warnings>all
     $(stacktrace_common_requirements)
     <target-os>linux:<library>dl
     <library>backtrace
+    <link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
     [ check-target-builds libbacktrace : : <build>no ]
     <conditional>@$(build-stacktrace-feature backtrace)
   : # default build
   : # usage-requirements
     #<link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
+    <define>BOOST_STACKTRACE_NO_LIB=1
   ;
 
 rule build-stacktrace-addr2line ( props * )
@@ -125,52 +124,60 @@ lib boost_stacktrace_addr2line
   : # sources
     ../src/addr2line.cpp
   : # requirements
-    $(stacktrace_common_requirements)
+    <warnings>all
     <target-os>linux:<library>dl
+    <link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
     [ check-target-builds addr2line : : <build>no ]
     <conditional>@build-stacktrace-addr2line
   : # default build
   : # usage-requirements
     #<link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
+    <define>BOOST_STACKTRACE_NO_LIB=1
   ;
 
 lib boost_stacktrace_basic
   : # sources
     ../src/basic.cpp
   : # requirements
-    $(stacktrace_common_requirements)
+    <warnings>all
     <target-os>linux:<library>dl
+    <link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
     [ check-target-builds WinDbg : <build>no ]
     <conditional>@$(build-stacktrace-feature basic)
   : # default build
   : # usage-requirements
     #<link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
+    <define>BOOST_STACKTRACE_NO_LIB=1
   ;
 
 lib boost_stacktrace_windbg
   : # sources
     ../src/windbg.cpp
   : # requirements
-    $(stacktrace_common_requirements)
+    <warnings>all
     <library>Dbgeng <library>ole32
+    <link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
     [ check-target-builds WinDbg : : <build>no ]
-    <conditional>@$(build-stacktrace-feature windbg)
+    [ build-stacktrace-feature windbg ]
   : # default build
   : # usage-requirements
     #<link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
+    <define>BOOST_STACKTRACE_NO_LIB=1
   ;
 
 lib boost_stacktrace_windbg_cached
   : # sources
     ../src/windbg_cached.cpp
   : # requirements
-    $(stacktrace_common_requirements)
+    <warnings>all
     <library>Dbgeng <library>ole32
+    <link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
     [ check-target-builds WinDbgCached : : <build>no ]
-    <conditional>@$(build-stacktrace-feature windbg-cached)
+    [ build-stacktrace-feature windbg-cached ]
   : # default build
   : # usage-requirements
     #<link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
+    <define>BOOST_STACKTRACE_NO_LIB=1
   ;
 
 rule build-stacktrace-from-exception ( props * )
@@ -193,7 +200,7 @@ lib boost_stacktrace_from_exception
   : # sources
     ../src/from_exception.cpp
   : # requirements
-    $(stacktrace_common_requirements)
+    <warnings>all
     <target-os>linux:<library>dl
 
     # Enable build when explicitly requested, or by default, when on x86
@@ -204,4 +211,5 @@ lib boost_stacktrace_from_exception
   : # default build
   : # usage-requirements
     #<link>shared:<define>BOOST_STACKTRACE_DYN_LINK=1
+    <define>BOOST_STACKTRACE_NO_LIB=1
   ;


### PR DESCRIPTION
Hello! As I commented in the issue #195, this PR exposes all stacktrace libraries as boost features, mirroring what's available in the CMakeLists.txt in this project. So users will be able to build or not specific libraries present in this project. Here are some keypoints to evaluate these new changes:

- Added `build-stacktrace-feature` as generic rule validate on/off entry from users for each feature
- For `addr2line` I added a rule to disable in case using Windows and not Cygwin. It reflects the rule present in CMakeLists.txt: https://github.com/boostorg/stacktrace/blob/develop/CMakeLists.txt#L67

close #195