### PR TITLE
Simplify has_addr2line check to not link with C++ Standard Library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           - toolset: gcc-9
             cxxstd: "03,11,14,17,2a"
             os: ubuntu-22.04
+            install: g++-9
           - toolset: clang-15
             cxxstd: "03,11,14,17,2a"
             os: ubuntu-22.04

--- a/build/has_addr2line.cpp
+++ b/build/has_addr2line.cpp
@@ -1,11 +1,10 @@
-// Copyright Antony Polukhin, 2016-2020.
+// Copyright Antony Polukhin, 2016-2025.
 //
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #include <cstdlib>
-#include <string>
 
 #include <boost/config.hpp>
 #include <unwind.h>
@@ -15,11 +14,10 @@
 int main() {
 
 #ifdef BOOST_STACKTRACE_ADDR2LINE_LOCATION
-    std::string s = BOOST_STRINGIZE( BOOST_STACKTRACE_ADDR2LINE_LOCATION );
-    s += " -h";
+    const char* s = BOOST_STRINGIZE( BOOST_STACKTRACE_ADDR2LINE_LOCATION ) " -h";
 #else
-    std::string s = "/usr/bin/addr2line -h";
+    const char* s = "/usr/bin/addr2line -h";
 #endif
 
-    return std::system(s.c_str());
+    return std::system(s);
 }


### PR DESCRIPTION
Fixes: https://github.com/boostorg/stacktrace/issues/209