### PR TITLE
Enable stack traces from exception on ARM by default if using libstdc++.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,8 +71,10 @@ endif()
 stacktrace_check(BOOST_STACKTRACE_HAS_WINDBG has_windbg.cpp "" "dbgeng;ole32" "")
 stacktrace_check(BOOST_STACKTRACE_HAS_WINDBG_CACHED has_windbg_cached.cpp "${CMAKE_CURRENT_SOURCE_DIR}/../config/include" "dbgeng;ole32" "")
 
+stacktrace_check(BOOST_STACKTRACE_USES_LIBSTDCPP uses_libstdc++.cpp "" "" "")
+
 set(_default_from_exception ON)
-if (NOT CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|amd64|i386|i686|x86")
+if ((NOT CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|amd64|i386|i686|x86") AND (NOT BOOST_STACKTRACE_USES_LIBSTDCPP))
   set(_default_from_exception OFF)
 endif()
 

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -64,6 +64,9 @@ explicit WinDbg ;
 mp-run-simple has_windbg_cached.cpp : : : <library>Dbgeng <library>ole32 : WinDbgCached ;
 explicit WinDbgCached ;
 
+mp-run-simple uses_libstdc++.cpp : : : : UsesLibStdCpp ;
+explicit UsesLibStdCpp ;
+
 rule build-stacktrace-noop ( props * )
 {
     local enabled = [ property.select <boost.stacktrace.noop> : $(props) ] ;
@@ -252,8 +255,11 @@ rule build-stacktrace-from-exception ( props * )
     local arch = [ property.select <architecture> : $(props) ] ;
     if $(arch) && ( $(arch:G=) != x86 )
     {
-        configure.log-library-search-result "boost.stacktrace.from_exception" : "no" ;
-        return <build>no ;
+        if ! [ configure.builds UsesLibStdCpp : $(props) : "boost.stacktrace.from_exception" ]
+        {
+            configure.log-library-search-result "boost.stacktrace.from_exception" : "no" ;
+            return <build>no ;
+        }
     }
     configure.log-library-search-result "boost.stacktrace.from_exception" : "yes" ;
 }

--- a/build/uses_libstdc++.cpp
+++ b/build/uses_libstdc++.cpp
@@ -1,0 +1,15 @@
+// Copyright Romain Geissler, 2025.
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <cstdlib>
+
+int main() {
+#ifdef __GLIBCXX__
+    return 0;
+#else
+#error "The C++ runtime library isn't libstdc++"
+#endif
+}

--- a/src/from_exception.cpp
+++ b/src/from_exception.cpp
@@ -164,6 +164,12 @@ BOOST_SYMBOL_EXPORT void assert_no_pending_traces() noexcept {
 #include <mutex>
 #include <unordered_map>
 
+// If we use libstdc++, we know the current implementation works and doesn't leak.
+// It's not the case of libc++ where we know there might be leaks and thus we try
+// to ensure the user is aware about it and only build this when
+// BOOST_STACKTRACE_LIBCXX_RUNTIME_MAY_CAUSE_MEMORY_LEAK is defined.
+#ifndef __GLIBCXX__
+
 #ifndef BOOST_STACKTRACE_LIBCXX_RUNTIME_MAY_CAUSE_MEMORY_LEAK
 
 #ifdef BOOST_HAS_THREADS
@@ -178,6 +184,8 @@ BOOST_SYMBOL_EXPORT void assert_no_pending_traces() noexcept {
         \
         Otherwise, disable the boost_stacktrace_from_exception library build \
         (for example by `./b2 boost.stacktrace.from_exception=off` option).
+
+#endif
 
 #endif
 


### PR DESCRIPTION
We know the implementation works on any architecture if libstdc++ is used (leaks are with libc++). So enable it by default in that case, even if not using x86.

Related to #163