### PR TITLE
Disable from_exception on cygwin.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ stacktrace_check(BOOST_STACKTRACE_HAS_WINDBG has_windbg.cpp "" "dbgeng;ole32" ""
 stacktrace_check(BOOST_STACKTRACE_HAS_WINDBG_CACHED has_windbg_cached.cpp "${CMAKE_CURRENT_SOURCE_DIR}/../config/include" "dbgeng;ole32" "")
 
 set(_default_from_exception ON)
-if (NOT CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|amd64|i386|i686|x86")
+if (NOT CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|amd64|i386|i686|x86" OR CMAKE_CXX_PLATFORM_ID MATCHES "Cygwin")
   set(_default_from_exception OFF)
 endif()
 

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -250,7 +250,7 @@ rule build-stacktrace-from-exception ( props * )
     }
 
     local arch = [ property.select <architecture> : $(props) ] ;
-    if $(arch) && ( $(arch:G=) != x86 )
+    if ( $(arch) && ( $(arch:G=) != x86 ) ) || ( <target-os>cygwin in $(props) )
     {
         configure.log-library-search-result "boost.stacktrace.from_exception" : "no" ;
         return <build>no ;


### PR DESCRIPTION
Cygwin doesn't have RTDL_NEXT, which causes a compile error with the non-windows implementation.  I'm not sure which implementation would be better to use, so just disable it for now.

This is part of a set of changes to fix boost on cygwin.  You can see the other submodules that will require changes here:

https://github.com/boostorg/boost/compare/master...corngood:boost:cygwin

These are based on the out-of-date downstream patches in cygwin:

https://cygwin.com/cgit/cygwin-packages/boost/tree/