### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/test/cmake_subdir_test/CMakeLists.txt
+++ b/test/cmake_subdir_test/CMakeLists.txt
@@ -28,7 +28,6 @@ winapi
 
 describe
 mp11
-static_assert
 throw_exception
 
 )


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.