### PR TITLE
Fix from_exception link on mingw

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -29,6 +29,7 @@ lib dl ;
 lib gcc_s ;
 lib Dbgeng ;
 lib ole32 ;
+lib ucrt ;
 
 local LIBBACKTRACE_PATH = [ modules.peek : LIBBACKTRACE_PATH ] ;
 lib backtrace
@@ -263,6 +264,7 @@ lib boost_stacktrace_from_exception
   : # requirements
     <warnings>all
     <target-os>linux:<library>dl
+    <target-os>windows:<library>ucrt
 
     # Enable build when explicitly requested, or by default, when on x86
     <conditional>@build-stacktrace-from-exception


### PR DESCRIPTION
Fixes the following linker error:
from_exception:(.text+0x9b): undefined reference to `__current_exception'

Amends 23e1213f54e2ef0bd89ac2beadc4ca5c1a510228.