### PR TITLE
Wrong fallback logic for name() libbacktrace backend

### DIFF
--- a/include/boost/stacktrace/detail/libbacktrace_impls.hpp
+++ b/include/boost/stacktrace/detail/libbacktrace_impls.hpp
@@ -49,14 +49,20 @@ inline void libbacktrace_syminfo_callback(void *data, uintptr_t pc, const char *
 
 inline int libbacktrace_full_callback(void *data, uintptr_t /*pc*/, const char *filename, int lineno, const char *function) {
     pc_data& d = *static_cast<pc_data*>(data);
+    int return_value = 0;
     if (d.filename && filename) {
         *d.filename = filename;
+        return_value = 1;
     }
     if (d.function && function) {
         *d.function = function;
+        return_value = 1;
     }
     d.line = static_cast<std::size_t>(lineno);
-    return 0;
+    if (d.line) {
+        return_value = 1;
+    }
+    return return_value;
 }
 
 inline void libbacktrace_error_callback(void* /*data*/, const char* /*msg*/, int /*errnum*/) noexcept {


### PR DESCRIPTION
Fixes #212

https://github.com/ianlancetaylor/libbacktrace/blob/master/backtrace.h#L180 shows that the return value of `backtrace_pcinfo` depends on the return value of the `callback` function. But the current `libbacktrace_full_callback` always returns 0:
https://github.com/boostorg/stacktrace/blob/4f8cabb87fb35044d5df44ae44cbf57904c65189/include/boost/stacktrace/detail/libbacktrace_impls.hpp#L50-L60
This leads the invocation of `backtrace_pcinfo` to always return 0, which makes the logical OR expression always evaluate the right hand side `backtrace_syminfo`:
https://github.com/boostorg/stacktrace/blob/4f8cabb87fb35044d5df44ae44cbf57904c65189/include/boost/stacktrace/detail/libbacktrace_impls.hpp#L177-L191
Therefore, the result from `backtrace_pcinfo` is always overwritten by the result from `backtrace_syminfo`.

As a solution, `libbacktrace_full_callback` will now return 1 only when there's valid data. 